### PR TITLE
Fix Yarn renovate config for moon

### DIFF
--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -2,7 +2,7 @@ node:
   version: "~22.11.0" # renovate: datasource=npm depName=node
   packageManager: "yarn"
   yarn:
-    version: "4.5.1" # renovate: datasource=npm depName=yarn
+    version: "4.5.1" # renovate: datasource=npm depName=@yarnpkg/cli
 
 typescript:
   # Prevent Moon from syncing `references` and `compilerOptions.paths` in the


### PR DESCRIPTION
This pull request includes a minor change to the `.moon/toolchain.yml` file. The change updates the `yarn` version reference to use the correct package name.

* [`.moon/toolchain.yml`](diffhunk://#diff-9e69e94edf8c6f7a6d5a85bf548d7c646d4b1ffed72d76a6b2a9b5d2f12af21aL5-R5): Updated the `yarn` version reference to `@yarnpkg/cli` to reflect the correct package name.