### PR TITLE
Upgrade TypeScript to 5.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@yarnpkg/types": "^4.0.0",
     "prettier": "^3.3.2",
     "semver": "^7.5.0",
-    "typescript": "^5.5.2"
+    "typescript": "^5.7.2"
   },
   "engines": {
     "node": "~22.11.0"

--- a/projects/app/package.json
+++ b/projects/app/package.json
@@ -94,7 +94,7 @@
     "prettier-plugin-tailwindcss": "^0.6.8",
     "ts-essentials": "^10.0.3",
     "tsx": "^4.15.7",
-    "typescript": "^5.5.2",
+    "typescript": "^5.7.2",
     "typescript-eslint": "^8.14.0",
     "ucd-full": "^16.0.0",
     "yargs": "^17.7.2"

--- a/projects/app/tsconfig.json
+++ b/projects/app/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": true,
     "baseUrl": ".",
     "esModuleInterop": true,
-    "jsx": "react-native",
+    "jsx": "preserve",
     "lib": ["DOM", "ESNext"],
     "module": "ES2020",
     "moduleResolution": "Bundler",

--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -13,7 +13,7 @@
     "@types/lodash": "4.17.x",
     "prettier": "^3.3.2",
     "tsx": "^4.15.7",
-    "typescript": "^5.5.2"
+    "typescript": "^5.7.2"
   },
   "private": true
 }

--- a/projects/static/package.json
+++ b/projects/static/package.json
@@ -6,7 +6,7 @@
     "@types/yargs": "^17 <=17.7.x",
     "prettier": "^3.3.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.5.2",
+    "typescript": "^5.7.2",
     "yargs": "^17.7.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,7 +2786,7 @@ __metadata:
     tailwindcss: "npm:^3.4.14"
     ts-essentials: "npm:^10.0.3"
     tsx: "npm:^4.15.7"
-    typescript: "npm:^5.5.2"
+    typescript: "npm:^5.7.2"
     typescript-eslint: "npm:^8.14.0"
     ucd-full: "npm:^16.0.0"
     ws: "npm:^8.17.1"
@@ -2816,7 +2816,7 @@ __metadata:
     nanoid: "npm:^5.0.7"
     prettier: "npm:^3.3.2"
     tsx: "npm:^4.15.7"
-    typescript: "npm:^5.5.2"
+    typescript: "npm:^5.7.2"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -2829,7 +2829,7 @@ __metadata:
     "@types/yargs": "npm:^17 <=17.7.x"
     prettier: "npm:^3.3.2"
     ts-node: "npm:^10.9.2"
-    typescript: "npm:^5.5.2"
+    typescript: "npm:^5.7.2"
     yargs: "npm:^17.7.2"
   languageName: unknown
   linkType: soft
@@ -11428,7 +11428,7 @@ __metadata:
     "@yarnpkg/types": "npm:^4.0.0"
     prettier: "npm:^3.3.2"
     semver: "npm:^7.5.0"
-    typescript: "npm:^5.5.2"
+    typescript: "npm:^5.7.2"
   languageName: unknown
   linkType: soft
 
@@ -17760,13 +17760,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.5.2":
-  version: 5.6.3
-  resolution: "typescript@npm:5.6.3"
+"typescript@npm:^5.5.2, typescript@npm:^5.7.2":
+  version: 5.7.2
+  resolution: "typescript@npm:5.7.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
+  checksum: 10c0/a873118b5201b2ef332127ef5c63fb9d9c155e6fdbe211cbd9d8e65877283797cca76546bad742eea36ed7efbe3424a30376818f79c7318512064e8625d61622
   languageName: node
   linkType: hard
 
@@ -17780,13 +17780,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.5.2#optional!builtin<compat/typescript>":
-  version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
+"typescript@patch:typescript@npm%3A^5.5.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.2#optional!builtin<compat/typescript>":
+  version: 5.7.2
+  resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/7c9d2e07c81226d60435939618c91ec2ff0b75fbfa106eec3430f0fcf93a584bc6c73176676f532d78c3594fe28a54b36eb40b3d75593071a7ec91301533ace7
+  checksum: 10c0/f3b8082c9d1d1629a215245c9087df56cb784f9fb6f27b5d55577a20e68afe2a889c040aacff6d27e35be165ecf9dca66e694c42eb9a50b3b2c451b36b5675cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request includes updates to the TypeScript version across multiple project files and a change to the `jsx` configuration in the `tsconfig.json` file.

TypeScript version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R14): Updated TypeScript from `^5.5.2` to `^5.7.2`.
* [`projects/app/package.json`](diffhunk://#diff-9ebcf40364ca0b131bfb1e02aa3cade3f1b8c39a09abca94223fd5829223b9f6L97-R97): Updated TypeScript from `^5.5.2` to `^5.7.2`.
* [`projects/lib/package.json`](diffhunk://#diff-e65c095bdffa59d160d94afa4bdce1ea696696b1424f7117d107436e65626d1dL16-R16): Updated TypeScript from `^5.5.2` to `^5.7.2`.
* [`projects/static/package.json`](diffhunk://#diff-d30c8e44b62493a0183eac313d2a45e004e6b22220392a323166141008011496L9-R9): Updated TypeScript from `^5.5.2` to `^5.7.2`.

Configuration change:

* [`projects/app/tsconfig.json`](diffhunk://#diff-424f1263ebdc5b114f4eb9ebf96813535a5942d7b9d02c67507153cf84fbbc8cL7-R7): Changed `jsx` configuration from `react-native` to `preserve`.


Changed tsconfig `jsx` option to `preserve` to avoid errors about React UMD global. The only difference between `react-native` and `preserve` is the output file extension (`.js` vs `.jsx`).