### PR TITLE
Add index scan support to rizzle

### DIFF
--- a/projects/app/eslint.config.mjs
+++ b/projects/app/eslint.config.mjs
@@ -178,6 +178,9 @@ export default tseslint.config(
       "@typescript-eslint/no-unnecessary-condition": `error`,
       // Expo/metro stuff still uses require().
       "@typescript-eslint/no-require-imports": `off`,
+      // A bit buggy when vars are only used as types, sticking with
+      // noUnusedLocals and noUnusedParameters.
+      "@typescript-eslint/no-unused-vars": `off`,
 
       //
       // @stylistic
@@ -209,6 +212,7 @@ export default tseslint.config(
     rules: {
       "@typescript-eslint/no-non-null-assertion": `off`,
       "@typescript-eslint/restrict-template-expressions": `off`,
+      "@typescript-eslint/require-await": `off`, // this is annoying when you want a little function to return a promise
     },
   },
 

--- a/projects/app/src/app/dev/ui.tsx
+++ b/projects/app/src/app/dev/ui.tsx
@@ -300,7 +300,7 @@ const Section = ({
         <View className="light-theme flex-1 bg-primary-4 p-2 hover:bg-primary-5">
           <Pressable
             onPress={() => {
-              ref.current?.measure((x, y) => {
+              ref.current?.measure((_x, y) => {
                 scrollTo(y);
               });
             }}

--- a/projects/app/src/app/learn/reviews.tsx
+++ b/projects/app/src/app/learn/reviews.tsx
@@ -2,7 +2,7 @@ import { QuizDeck } from "@/components/QuizDeck";
 import { RectButton } from "@/components/RectButton";
 import { useQueryOnce } from "@/components/ReplicacheContext";
 import { generateQuestionForSkillOrThrow } from "@/data/generator";
-import { IndexName, indexScanIter } from "@/data/marshal";
+import { IndexName, legacyIndexScanIter } from "@/data/marshal";
 import { questionsForReview } from "@/data/query";
 import { formatDuration } from "date-fns/formatDuration";
 import { interval } from "date-fns/interval";
@@ -26,7 +26,7 @@ export default function ReviewsPage() {
 
   const nextNotYetDueSkillState = useQueryOnce(async (tx) => {
     const now = new Date();
-    for await (const [skill, skillState] of indexScanIter(
+    for await (const [skill, skillState] of legacyIndexScanIter(
       tx,
       IndexName.SkillStateByDue,
     )) {

--- a/projects/app/src/data/generator.ts
+++ b/projects/app/src/data/generator.ts
@@ -47,7 +47,6 @@ const choicePair = (
 });
 
 function keyForChoice(choice: OneCorrectPairQuestionChoice) {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { skill, type, ...rest } = choice;
   return JSON.stringify(rest);
 }

--- a/projects/app/src/data/query.ts
+++ b/projects/app/src/data/query.ts
@@ -3,7 +3,7 @@ import shuffle from "lodash/shuffle";
 import take from "lodash/take";
 import { ReadTransaction } from "replicache";
 import { generateQuestionForSkillOrThrow } from "./generator";
-import { IndexName, indexScanIter } from "./marshal";
+import { IndexName, legacyIndexScanIter } from "./marshal";
 import { Question, Skill, SkillState, SkillType } from "./model";
 
 export async function questionsForReview(
@@ -20,7 +20,7 @@ export async function questionsForReview(
   const now = new Date();
   const skillTypesFilter =
     options?.skillTypes != null ? new Set(options.skillTypes) : null;
-  for await (const [skill, skillState] of indexScanIter(
+  for await (const [skill, skillState] of legacyIndexScanIter(
     tx,
     IndexName.SkillStateByDue,
   )) {

--- a/projects/app/src/env.ts
+++ b/projects/app/src/env.ts
@@ -2,8 +2,6 @@ import { TEST_LICENSE_KEY } from "replicache";
 import z from "zod";
 
 const nonEmptyString = z.string().min(1);
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const parseString = (x: unknown) => nonEmptyString.parse(x);
 
 export const replicacheLicenseKey = nonEmptyString
   // The special value `TEST_LICENSE_KEY` swaps to the test key from replicache.

--- a/projects/app/src/typings/eslint__eslintrc.d.ts
+++ b/projects/app/src/typings/eslint__eslintrc.d.ts
@@ -4,7 +4,6 @@ declare module "@eslint/eslintrc" {
     FlatConfig,
   } from "@typescript-eslint/utils/ts-eslint";
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   declare class FlatCompat {
     constructor(options?: {
       baseDirectory?: string;

--- a/projects/static/src/bin/generateSpeech.ts
+++ b/projects/static/src/bin/generateSpeech.ts
@@ -12,7 +12,7 @@ yargs(hideBin(process.argv))
     "$0",
     "generate audio files for each phrase and voice",
     (y) => y,
-    async (argv) => {
+    async () => {
       for (const voice of voices) {
         for (const phrase of phrases) {
           const tempPath = "speech.aac";

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,10 +8,12 @@
     "composite": true,
     "declaration": true,
     "declarationMap": true,
-    "noEmit": false,
     "emitDeclarationOnly": true,
     "incremental": true,
+    "noEmit": false,
     "noEmitOnError": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true
   }
 }


### PR DESCRIPTION
This pull request includes several changes to the ESLint configuration and test files in the project. The most important changes include updates to ESLint rules, improvements in type checking and test cases, and the addition of new utility functions for parsing key paths.

### ESLint Configuration Updates:
* Disabled the `@typescript-eslint/no-unused-vars` rule due to its buggy behavior when variables are only used as types.
* Disabled the `@typescript-eslint/require-await` rule as it is considered annoying when small functions return a promise.

### Test File Enhancements:
* Added new imports and utility functions for type checking in `marshal.test.ts`. [[1]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eR7-R12) [[2]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eR26-R29)
* Replaced `test.skip` with `typeChecks` to ensure type checking is performed without running the tests. [[1]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eR61-R91) [[2]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL75-R100) [[3]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL88-R125)
* Improved the `makeMockTx` function by removing unnecessary eslint-disable comments and adding new mock implementations for `scan` and `set` methods. (Fb764b98L109R138)

### Test Case Improvements:
* Enhanced various test cases in the `rizzle` suite to include type checks and better assertions. (Fb764b98L118R312, Fb764b98L221R348, [[1]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL369-R460) [[2]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL482-R635)
* Added a new test case for the `index scan` functionality.
* Added a new test case for the `parseKeyPath` utility function.

### Code Simplification:
* Simplified the `measure` function call in `ui.tsx` by ignoring the `x` parameter.