### PR TITLE
upgrade prettier to 3.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@yarnpkg/doctor": "^4.0.2",
     "@yarnpkg/parsers": "^3.0.2",
     "@yarnpkg/types": "^4.0.0",
-    "prettier": "^3.4.1",
+    "prettier": "^3.4.2",
     "semver": "^7.5.0",
     "typescript": "^5.7.2"
   },

--- a/projects/app/package.json
+++ b/projects/app/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "globals": "^15.0.0",
     "openai": "^4.68.4",
-    "prettier": "^3.4.1",
+    "prettier": "^3.4.2",
     "prettier-plugin-tailwindcss": "^0.6.9",
     "ts-essentials": "^10.0.3",
     "tsx": "^4.15.7",

--- a/projects/app/src/app/(sidenav)/radical/new/[id].tsx
+++ b/projects/app/src/app/(sidenav)/radical/new/[id].tsx
@@ -218,9 +218,8 @@ export default function RadicalPage() {
               <View className="flex-1">
                 <Text className="text-text">
                   <Text className="opacity-50">The</Text> 一 at the top{` `}
-                  <Text className="opacity-50">
-                    is like a
-                  </Text> straight line or a boundary.
+                  <Text className="opacity-50">is like a</Text> straight line or
+                  a boundary.
                 </Text>
               </View>
             </View>
@@ -252,13 +251,10 @@ export default function RadicalPage() {
               <View className="flex-1">
                 <Text className="text-text">
                   <Text className="opacity-50">The</Text> 尢 underneath{` `}
-                  <Text className="opacity-50">
-                    looks like a
-                  </Text> person trying to stand{` `}
-                  <Text className="opacity-50">
-                    but bending in a way
-                  </Text> they can <Text className="underline">not</Text> fully
-                  rise.
+                  <Text className="opacity-50">looks like a</Text> person trying
+                  to stand{` `}
+                  <Text className="opacity-50">but bending in a way</Text> they
+                  can <Text className="underline">not</Text> fully rise.
                 </Text>
               </View>
             </View>

--- a/projects/emails/package.json
+++ b/projects/emails/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@types/react": "18.3.x",
-    "prettier": "^3.4.1"
+    "prettier": "^3.4.2"
   }
 }

--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/lodash": "4.17.x",
-    "prettier": "^3.4.1",
+    "prettier": "^3.4.2",
     "tsx": "^4.15.7",
     "typescript": "^5.7.2"
   },

--- a/projects/static/package.json
+++ b/projects/static/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "@types/node": "^22.8.0",
     "@types/yargs": "^17 <=17.7.x",
-    "prettier": "^3.4.1",
+    "prettier": "^3.4.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.2",
     "yargs": "^17.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2756,7 +2756,7 @@ __metadata:
     openai: "npm:^4.68.4"
     oslo: "npm:^1.2.1"
     pg: "npm:^8.12.0"
-    prettier: "npm:^3.4.1"
+    prettier: "npm:^3.4.2"
     prettier-plugin-tailwindcss: "npm:^0.6.9"
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
@@ -2789,7 +2789,7 @@ __metadata:
   dependencies:
     "@react-email/components": "npm:^0.0.28"
     "@types/react": "npm:18.3.x"
-    prettier: "npm:^3.4.1"
+    prettier: "npm:^3.4.2"
     react: "npm:~18.3.1"
     react-email: "npm:^2.1.2"
   languageName: unknown
@@ -2802,7 +2802,7 @@ __metadata:
     "@types/lodash": "npm:4.17.x"
     lodash: "npm:^4.17.21"
     nanoid: "npm:^5.0.9"
-    prettier: "npm:^3.4.1"
+    prettier: "npm:^3.4.2"
     tsx: "npm:^4.15.7"
     typescript: "npm:^5.7.2"
     zod: "npm:^3.23.8"
@@ -2815,7 +2815,7 @@ __metadata:
   dependencies:
     "@types/node": "npm:^22.8.0"
     "@types/yargs": "npm:^17 <=17.7.x"
-    prettier: "npm:^3.4.1"
+    prettier: "npm:^3.4.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.7.2"
     yargs: "npm:^17.7.2"
@@ -11435,7 +11435,7 @@ __metadata:
     "@yarnpkg/doctor": "npm:^4.0.2"
     "@yarnpkg/parsers": "npm:^3.0.2"
     "@yarnpkg/types": "npm:^4.0.0"
-    prettier: "npm:^3.4.1"
+    prettier: "npm:^3.4.2"
     semver: "npm:^7.5.0"
     typescript: "npm:^5.7.2"
   languageName: unknown
@@ -15092,12 +15092,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.4.1":
-  version: 3.4.1
-  resolution: "prettier@npm:3.4.1"
+"prettier@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "prettier@npm:3.4.2"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/2d6cc3101ad9de72b49c59339480b0983e6ff6742143da0c43f476bf3b5ef88ede42ebd9956d7a0a8fa59f7a5990e8ef03c9ad4c37f7e4c9e5db43ee0853156c
+  checksum: 10c0/99e076a26ed0aba4ebc043880d0f08bbb8c59a4c6641cdee6cdadf2205bdd87aa1d7823f50c3aea41e015e99878d37c58d7b5f0e663bba0ef047f94e36b96446
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request includes updates to the `prettier` dependency across multiple `package.json` files to ensure consistency in the code formatting tool version.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R12): Updated `prettier` from `^3.4.1` to `^3.4.2`.
* [`projects/app/package.json`](diffhunk://#diff-9ebcf40364ca0b131bfb1e02aa3cade3f1b8c39a09abca94223fd5829223b9f6L93-R93): Updated `prettier` from `^3.4.1` to `^3.4.2`.
* [`projects/emails/package.json`](diffhunk://#diff-bd9105077403a52cd68eff74c3fde6de8b78ce764b2e38ed2b39e0048cbe9c45L12-R12): Updated `prettier` from `^3.4.1` to `^3.4.2`.
* [`projects/lib/package.json`](diffhunk://#diff-e65c095bdffa59d160d94afa4bdce1ea696696b1424f7117d107436e65626d1dL14-R14): Updated `prettier` from `^3.4.1` to `^3.4.2`.
* [`projects/static/package.json`](diffhunk://#diff-d30c8e44b62493a0183eac313d2a45e004e6b22220392a323166141008011496L7-R7): Updated `prettier` from `^3.4.1` to `^3.4.2`.