### PR TITLE
Use strict assertion in tests

### DIFF
--- a/.yarn/patches/replicache-npm-14.2.2-d99f6a2b5c.patch
+++ b/.yarn/patches/replicache-npm-14.2.2-d99f6a2b5c.patch
@@ -1,0 +1,37 @@
+diff --git a/out/replicache.d.ts b/out/replicache.d.ts
+index 00c15e9b300defc0f1df7779cf25edf348cd864c..3ce8194a2788b4b36272f1f24fddf2038c1774b2 100644
+--- a/out/replicache.d.ts
++++ b/out/replicache.d.ts
+@@ -10,7 +10,7 @@ type JSONValue =
+   | string
+   | boolean
+   | number
+-  | Array<JSONValue>
++  | Array<unknown>
+   | JSONObject;
+ 
+ /**
+@@ -27,7 +27,7 @@ type JSONValue =
+  * console.log(v); // either {a: undefined} or {}
+  * ```
+  */
+-type JSONObject = {[key: string]: JSONValue | undefined};
++type JSONObject = {[key: string]: unknown};
+ 
+ /** Like {@link JSONValue} but deeply readonly */
+ type ReadonlyJSONValue =
+@@ -35,12 +35,12 @@ type ReadonlyJSONValue =
+   | string
+   | boolean
+   | number
+-  | ReadonlyArray<ReadonlyJSONValue>
++  | ReadonlyArray<unknown>
+   | ReadonlyJSONObject;
+ 
+ /** Like {@link JSONObject} but deeply readonly */
+ type ReadonlyJSONObject = {
+-  readonly [key: string]: ReadonlyJSONValue | undefined;
++  readonly [key: string]: unknown;
+ };
+ 
+ /**

--- a/.yarn/patches/replicache-patch-e568419bdf.patch
+++ b/.yarn/patches/replicache-patch-e568419bdf.patch
@@ -1,0 +1,20 @@
+diff --git a/out/replicache.d.ts b/out/replicache.d.ts
+index 3ce8194a2788b4b36272f1f24fddf2038c1774b2..39b823a4af3abacb2225991d1e954b3f33a16783 100644
+--- a/out/replicache.d.ts
++++ b/out/replicache.d.ts
+@@ -10,6 +10,7 @@ type JSONValue =
+   | string
+   | boolean
+   | number
++  | object
+   | Array<unknown>
+   | JSONObject;
+ 
+@@ -35,6 +36,7 @@ type ReadonlyJSONValue =
+   | string
+   | boolean
+   | number
++  | object
+   | ReadonlyArray<unknown>
+   | ReadonlyJSONObject;
+ 

--- a/projects/app/bin/generateHanziDecomposition.ts
+++ b/projects/app/bin/generateHanziDecomposition.ts
@@ -95,7 +95,7 @@ function parseIdsTxt(txt: string): ReadonlyMap<string, Decomposition[]> {
     const codePoint = parseInt(unicodeShortIdentifier.replace(`U+`, ``), 16);
     const characterFromCodePoint = String.fromCodePoint(codePoint);
 
-    assert.equal(character, characterFromCodePoint);
+    assert.strictEqual(character, characterFromCodePoint);
 
     const parsedDecompositions = [];
 

--- a/projects/app/package.json
+++ b/projects/app/package.json
@@ -59,7 +59,7 @@
     "react-native-svg": "15.8.0",
     "react-native-web": "^0.19.13",
     "react-responsive": "^10.0.0",
-    "replicache": "^14.2.2",
+    "replicache": "patch:replicache@patch%3Areplicache@npm%253A14.2.2%23~/.yarn/patches/replicache-npm-14.2.2-d99f6a2b5c.patch%3A%3Aversion=14.2.2&hash=f2490e#~/.yarn/patches/replicache-patch-e568419bdf.patch",
     "replicache-react": "^5.0.1",
     "tailwind-variants": "^0.2.1",
     "tailwindcss": "^3.4.14",

--- a/projects/app/src/__tests__/data/marshal.test.ts
+++ b/projects/app/src/__tests__/data/marshal.test.ts
@@ -112,28 +112,35 @@ typeChecks(`schema introspection helpers`, () => {
 });
 
 function makeMockTx(t: TestContext) {
-  const mockRtx = {
-    get: t.mock.fn((_id: string) =>
-      Promise.resolve<object | undefined>(undefined),
-    ),
-    scan: t.mock.fn((_options: { indexName: string }): unknown => {
-      return;
+  const readTx = {
+    get: t.mock.fn<ReadTransaction[`get`]>(async () => undefined),
+    scan: t.mock.fn<ReadTransaction[`scan`]>(() => {
+      return null as never;
     }),
-  };
-  const mockWtx = {
-    ...mockRtx,
-    set: t.mock.fn((_id: string, _data: unknown) =>
-      Promise.resolve<object | undefined>(undefined),
-    ),
-  };
+    clientID: null as never,
+    environment: null as never,
+    location: null as never,
+    has: null as never,
+    isEmpty: null as never,
+  } satisfies ReadTransaction;
+
+  const writeTx = {
+    ...readTx,
+    set: t.mock.fn<WriteTransaction[`set`]>(async () => undefined),
+    mutationID: null as never,
+    reason: null as never,
+    put: null as never,
+    del: null as never,
+  } satisfies WriteTransaction;
 
   return {
-    mockRtx,
-    mockWtx,
-    rtx: mockRtx as unknown as ReadTransaction,
-    wtx: mockWtx as unknown as WriteTransaction,
-    mockTx: mockWtx,
-    tx: mockWtx as unknown as WriteTransaction,
+    ...writeTx,
+    readonly: readTx,
+    [Symbol.dispose]: () => {
+      writeTx.get.mock.resetCalls();
+      writeTx.set.mock.resetCalls();
+      writeTx.scan.mock.resetCalls();
+    },
   };
 }
 
@@ -144,45 +151,43 @@ void suite(`rizzle`, () => {
       name: rizzle.string(),
     });
 
-    const { mockTx, rtx, wtx, tx } = makeMockTx(t);
+    using tx = makeMockTx(t);
 
     await posts.get(tx, { id: `1` });
-    assert.strictEqual(mockTx.get.mock.callCount(), 1);
-    assert.deepStrictEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1`]);
+    assert.strictEqual(tx.get.mock.callCount(), 1);
+    assert.deepStrictEqual(tx.get.mock.calls[0]?.arguments, [`foo/1`]);
 
     // Check that a ReadonlyJSONValue is parsed correctly.
-    mockTx.get.mock.mockImplementationOnce(() =>
-      Promise.resolve({ name: `foo` }),
-    );
+    tx.get.mock.mockImplementationOnce(() => Promise.resolve({ name: `foo` }));
     assert.deepStrictEqual(await posts.get(tx, { id: `1` }), { name: `foo` });
 
     // Check that a value is encoded correctly.
     await posts.set(tx, { id: `1` }, { name: `foo` });
-    assert.strictEqual(mockTx.set.mock.callCount(), 1);
-    assert.deepStrictEqual(mockTx.set.mock.calls[0]?.arguments, [
+    assert.strictEqual(tx.set.mock.callCount(), 1);
+    assert.deepStrictEqual(tx.set.mock.calls[0]?.arguments, [
       `foo/1`,
       { name: `foo` },
     ]);
 
     typeChecks(async () => {
       // .get()
-      void posts.get(rtx, { id: `1` });
+      void posts.get(tx.readonly, { id: `1` });
       // @ts-expect-error `id` is the key, not `name`
-      void posts.get(rtx, { name: `1` });
+      void posts.get(tx.readonly, { name: `1` });
       {
-        const post = await posts.get(rtx, { id: `1` });
+        const post = await posts.get(tx.readonly, { id: `1` });
         true satisfies AssertEqual<typeof post, { name: string } | undefined>;
       }
 
       // .set()
-      void posts.set(wtx, { id: `1` }, { name: `foo` });
+      void posts.set(tx, { id: `1` }, { name: `foo` });
       // @ts-expect-error `id` is the key, not `name`
-      void posts.set(wtx, { name: `1` }, { name: `foo` });
+      void posts.set(tx, { name: `1` }, { name: `foo` });
     });
   });
 
   void test(`object()`, async (t) => {
-    const { mockTx, tx, rtx, wtx } = makeMockTx(t);
+    using tx = makeMockTx(t);
 
     {
       // key alias
@@ -192,19 +197,17 @@ void suite(`rizzle`, () => {
       });
 
       await posts.get(tx, { id: `1` });
-      assert.strictEqual(mockTx.get.mock.callCount(), 1);
-      assert.deepStrictEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1`]);
+      assert.strictEqual(tx.get.mock.callCount(), 1);
+      assert.deepStrictEqual(tx.get.mock.calls[0]?.arguments, [`foo/1`]);
 
       // Check that a ReadonlyJSONValue is parsed correctly.
-      mockTx.get.mock.mockImplementationOnce(() =>
-        Promise.resolve({ n: `foo` }),
-      );
+      tx.get.mock.mockImplementationOnce(() => Promise.resolve({ n: `foo` }));
       assert.deepStrictEqual(await posts.get(tx, { id: `1` }), { name: `foo` });
 
       // Check that a value is encoded correctly.
       await posts.set(tx, { id: `1` }, { name: `foo` });
-      assert.strictEqual(mockTx.set.mock.callCount(), 1);
-      assert.deepStrictEqual(mockTx.set.mock.calls[0]?.arguments, [
+      assert.strictEqual(tx.set.mock.callCount(), 1);
+      assert.deepStrictEqual(tx.set.mock.calls[0]?.arguments, [
         `foo/1`,
         { n: `foo` },
       ]);
@@ -217,18 +220,18 @@ void suite(`rizzle`, () => {
       });
 
       // .get()
-      void posts.get(rtx, { id: `1` });
+      void posts.get(tx.readonly, { id: `1` });
       // @ts-expect-error `id` is the key, not `name`
-      void posts.get(rtx, { name: `1` });
+      void posts.get(tx.readonly, { name: `1` });
       {
-        const post = await posts.get(rtx, { id: `1` });
+        const post = await posts.get(tx.readonly, { id: `1` });
         true satisfies AssertEqual<typeof post, { name: string } | undefined>;
       }
 
       // .set()
-      void posts.set(wtx, { id: `1` }, { name: `foo` });
+      void posts.set(tx, { id: `1` }, { name: `foo` });
       // @ts-expect-error `id` is the key, not `name`
-      void posts.set(wtx, { name: `1` }, { name: `foo` });
+      void posts.set(tx, { name: `1` }, { name: `foo` });
     });
 
     typeChecks(`nested with aliases`, async () => {
@@ -267,11 +270,11 @@ void suite(`rizzle`, () => {
       due: rizzle.timestamp(),
     });
 
-    const { mockTx, tx } = makeMockTx(t);
+    using tx = makeMockTx(t);
 
     await posts.get(tx, { id: `1` });
-    assert.strictEqual(mockTx.get.mock.callCount(), 1);
-    assert.deepStrictEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1`]);
+    assert.strictEqual(tx.get.mock.callCount(), 1);
+    assert.deepStrictEqual(tx.get.mock.calls[0]?.arguments, [`foo/1`]);
 
     // Unmarshalling
     {
@@ -281,7 +284,7 @@ void suite(`rizzle`, () => {
         [date.getTime(), date], // timestamp as number
         [date.getTime().toString(), date], // timestamp as string
       ]) {
-        mockTx.get.mock.mockImplementationOnce(() =>
+        tx.get.mock.mockImplementationOnce(() =>
           Promise.resolve({ due: marshaled }),
         );
         assert.deepStrictEqual(
@@ -302,12 +305,12 @@ void suite(`rizzle`, () => {
         [date.getTime(), date.getTime()], // timestamp as number
       ] as const) {
         await posts.set(tx, { id: `1` }, { due: unmarshaled });
-        assert.strictEqual(mockTx.set.mock.callCount(), 1);
-        assert.deepStrictEqual(mockTx.set.mock.calls[0]?.arguments, [
+        assert.strictEqual(tx.set.mock.callCount(), 1);
+        assert.deepStrictEqual(tx.set.mock.calls[0]?.arguments, [
           `foo/1`,
           { due: marshaled },
         ]);
-        mockTx.set.mock.resetCalls();
+        tx.set.mock.resetCalls();
       }
     }
   });
@@ -317,8 +320,6 @@ void suite(`rizzle`, () => {
       id: rizzle.string(),
       skill: rizzle.skillType(),
     });
-
-    const { mockTx, tx } = makeMockTx(t);
 
     // Marshal and unmarshal round tripping
     for (const skillType of [
@@ -334,17 +335,16 @@ void suite(`rizzle`, () => {
       SkillType.PinyinToHanzi,
       SkillType.ImageToHanzi,
     ] as const) {
+      using tx = makeMockTx(t);
+
       await posts.set(tx, { id: `1` }, { skill: skillType });
-      const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
-      mockTx.get.mock.mockImplementationOnce(() =>
+      const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
+      tx.get.mock.mockImplementationOnce(() =>
         Promise.resolve(marshaledData as object),
       );
       assert.deepStrictEqual(await posts.get(tx, { id: `1` }), {
         skill: skillType,
       });
-
-      mockTx.get.mock.resetCalls();
-      mockTx.set.mock.resetCalls();
     }
   });
 
@@ -354,23 +354,19 @@ void suite(`rizzle`, () => {
       skill: rizzle.skillId(),
     });
 
-    const { mockTx, tx } = makeMockTx(t);
-
     // Marshal and unmarshal round tripping
     for (const skill of [
       { type: SkillType.EnglishToHanzi, hanzi: `好` },
     ] as const) {
+      using tx = makeMockTx(t);
       await posts.set(tx, { id: `1` }, { skill });
-      const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
-      mockTx.get.mock.mockImplementationOnce(() =>
+      const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
+      tx.get.mock.mockImplementationOnce(() =>
         Promise.resolve(marshaledData as object),
       );
       assert.deepStrictEqual(await posts.get(tx, { id: `1` }), {
         skill,
       });
-
-      mockTx.get.mock.resetCalls();
-      mockTx.set.mock.resetCalls();
     }
   });
 
@@ -380,21 +376,18 @@ void suite(`rizzle`, () => {
       text: rizzle.string(),
     });
 
-    const { mockTx, tx } = makeMockTx(t);
+    using tx = makeMockTx(t);
 
     await posts.set(tx, { id1: `1` }, { text: `hello` });
-    const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
-    mockTx.get.mock.mockImplementationOnce(() =>
+    const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
+    tx.get.mock.mockImplementationOnce(() =>
       Promise.resolve(marshaledData as object),
     );
     assert.deepStrictEqual(await posts.get(tx, { id1: `1` }), {
       text: `hello`,
     });
-    assert.strictEqual(mockTx.get.mock.callCount(), 1);
-    assert.deepStrictEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1`]);
-
-    mockTx.get.mock.resetCalls();
-    mockTx.set.mock.resetCalls();
+    assert.strictEqual(tx.get.mock.callCount(), 1);
+    assert.deepStrictEqual(tx.get.mock.calls[0]?.arguments, [`foo/1`]);
   });
 
   void test(`two keys`, async (t) => {
@@ -404,21 +397,18 @@ void suite(`rizzle`, () => {
       text: rizzle.string(),
     });
 
-    const { mockTx, tx } = makeMockTx(t);
+    using tx = makeMockTx(t);
 
     await posts.set(tx, { id1: `1`, id2: `2` }, { text: `hello` });
-    const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
-    mockTx.get.mock.mockImplementationOnce(() =>
+    const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
+    tx.get.mock.mockImplementationOnce(() =>
       Promise.resolve(marshaledData as object),
     );
     assert.deepStrictEqual(await posts.get(tx, { id1: `1`, id2: `2` }), {
       text: `hello`,
     });
-    assert.strictEqual(mockTx.get.mock.callCount(), 1);
-    assert.deepStrictEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1/2`]);
-
-    mockTx.get.mock.resetCalls();
-    mockTx.set.mock.resetCalls();
+    assert.strictEqual(tx.get.mock.callCount(), 1);
+    assert.deepStrictEqual(tx.get.mock.calls[0]?.arguments, [`foo/1/2`]);
   });
 
   void test(`non-string key codec`, async (t) => {
@@ -426,8 +416,6 @@ void suite(`rizzle`, () => {
       skill: rizzle.skillId(),
       text: rizzle.string(),
     });
-
-    const { mockTx, tx } = makeMockTx(t);
 
     // Marshal and unmarshal round tripping
     for (const [skill, skillId] of [
@@ -441,21 +429,19 @@ void suite(`rizzle`, () => {
         `rp:好:hǎo`,
       ],
     ] as const) {
+      using tx = makeMockTx(t);
       await posts.set(tx, { skill }, { text: `hello` });
-      const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
-      mockTx.get.mock.mockImplementationOnce(() =>
+      const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
+      tx.get.mock.mockImplementationOnce(() =>
         Promise.resolve(marshaledData as object),
       );
       assert.deepStrictEqual(await posts.get(tx, { skill }), {
         text: `hello`,
       });
-      assert.strictEqual(mockTx.get.mock.callCount(), 1);
-      assert.deepStrictEqual(mockTx.get.mock.calls[0]?.arguments, [
+      assert.strictEqual(tx.get.mock.callCount(), 1);
+      assert.deepStrictEqual(tx.get.mock.calls[0]?.arguments, [
         `foo/${skillId}`,
       ]);
-
-      mockTx.get.mock.resetCalls();
-      mockTx.set.mock.resetCalls();
     }
   });
 
@@ -473,13 +459,13 @@ void suite(`rizzle`, () => {
       }),
     });
 
-    const { mockTx, tx } = makeMockTx(t);
-
     // Marshal and unmarshal round tripping
     for (const color of [Colors.BLUE, Colors.RED]) {
+      using tx = makeMockTx(t);
+
       await posts.set(tx, { id: `1` }, { color });
-      const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
-      mockTx.get.mock.mockImplementationOnce(() =>
+      const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
+      tx.get.mock.mockImplementationOnce(() =>
         Promise.resolve(marshaledData as object),
       );
       // Make sure the enum isn't just being marshaled to its runtime value,
@@ -489,9 +475,6 @@ void suite(`rizzle`, () => {
       assert.deepStrictEqual(await posts.get(tx, { id: `1` }), {
         color,
       });
-
-      mockTx.get.mock.resetCalls();
-      mockTx.set.mock.resetCalls();
     }
   });
 
@@ -505,7 +488,7 @@ void suite(`rizzle`, () => {
       }),
     });
 
-    const { mockTx, tx } = makeMockTx(t);
+    using tx = makeMockTx(t);
 
     // Marshal and unmarshal round tripping
     await posts.set(
@@ -513,20 +496,17 @@ void suite(`rizzle`, () => {
       { id: `1` },
       { author: { name: `foo`, email: `f@o`, id: 1 } },
     );
-    const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
+    const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
     assert.deepStrictEqual(marshaledData, {
       author: { name: `foo`, e: `f@o`, i: 1 },
     });
 
-    mockTx.get.mock.mockImplementationOnce(() =>
+    tx.get.mock.mockImplementationOnce(() =>
       Promise.resolve(marshaledData as object),
     );
     assert.deepStrictEqual(await posts.get(tx, { id: `1` }), {
       author: { name: `foo`, email: `f@o`, id: 1 },
     });
-
-    mockTx.get.mock.resetCalls();
-    mockTx.set.mock.resetCalls();
   });
 
   void test(`object()`, async (t) => {
@@ -537,22 +517,19 @@ void suite(`rizzle`, () => {
       }),
     });
 
-    const { mockTx, tx } = makeMockTx(t);
+    using tx = makeMockTx(t);
 
     // Marshal and unmarshal round tripping
     await posts.set(tx, { id: `1` }, { author: { name: `foo` } });
-    const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
+    const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
     assert.deepStrictEqual(marshaledData, { author: { name: `foo` } });
 
-    mockTx.get.mock.mockImplementationOnce(() =>
+    tx.get.mock.mockImplementationOnce(() =>
       Promise.resolve(marshaledData as object),
     );
     assert.deepStrictEqual(await posts.get(tx, { id: `1` }), {
       author: { name: `foo` },
     });
-
-    mockTx.get.mock.resetCalls();
-    mockTx.set.mock.resetCalls();
   });
 
   void test(`object indexes`, () => {
@@ -588,9 +565,10 @@ void suite(`rizzle`, () => {
       }),
     });
 
-    const { mockTx, tx } = makeMockTx(t);
+    using tx = makeMockTx(t);
 
-    mockTx.scan.mock.mockImplementationOnce((options) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tx.scan.mock.mockImplementationOnce((options: any): any => {
       assert.deepStrictEqual(options, {
         indexName: `byAuthorName`,
         start: undefined,
@@ -602,7 +580,8 @@ void suite(`rizzle`, () => {
         },
       };
     }, 0);
-    mockTx.scan.mock.mockImplementationOnce((options) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tx.scan.mock.mockImplementationOnce((options: any): any => {
       assert.deepStrictEqual(options, {
         indexName: `byAuthorName`,
         start: {
@@ -667,22 +646,19 @@ void suite(`rizzle`, () => {
       count: rizzle.number(`c`),
     });
 
-    const { mockTx, tx } = makeMockTx(t);
+    using tx = makeMockTx(t);
 
     // Marshal and unmarshal round tripping
     await posts.set(tx, { id: `1` }, { count: 5 });
-    const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
+    const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
     assert.deepStrictEqual(marshaledData, { c: 5 });
 
-    mockTx.get.mock.mockImplementationOnce(() =>
+    tx.get.mock.mockImplementationOnce(() =>
       Promise.resolve(marshaledData as object),
     );
     assert.deepStrictEqual(await posts.get(tx, { id: `1` }), {
       count: 5,
     });
-
-    mockTx.get.mock.resetCalls();
-    mockTx.set.mock.resetCalls();
   });
 
   typeChecks(`RizzleIndexNames`, () => {

--- a/projects/app/src/__tests__/data/marshal.test.ts
+++ b/projects/app/src/__tests__/data/marshal.test.ts
@@ -147,19 +147,19 @@ void suite(`rizzle`, () => {
     const { mockTx, rtx, wtx, tx } = makeMockTx(t);
 
     await posts.get(tx, { id: `1` });
-    assert.equal(mockTx.get.mock.callCount(), 1);
-    assert.deepEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1`]);
+    assert.strictEqual(mockTx.get.mock.callCount(), 1);
+    assert.deepStrictEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1`]);
 
     // Check that a ReadonlyJSONValue is parsed correctly.
     mockTx.get.mock.mockImplementationOnce(() =>
       Promise.resolve({ name: `foo` }),
     );
-    assert.deepEqual(await posts.get(tx, { id: `1` }), { name: `foo` });
+    assert.deepStrictEqual(await posts.get(tx, { id: `1` }), { name: `foo` });
 
     // Check that a value is encoded correctly.
     await posts.set(tx, { id: `1` }, { name: `foo` });
-    assert.equal(mockTx.set.mock.callCount(), 1);
-    assert.deepEqual(mockTx.set.mock.calls[0]?.arguments, [
+    assert.strictEqual(mockTx.set.mock.callCount(), 1);
+    assert.deepStrictEqual(mockTx.set.mock.calls[0]?.arguments, [
       `foo/1`,
       { name: `foo` },
     ]);
@@ -192,19 +192,19 @@ void suite(`rizzle`, () => {
       });
 
       await posts.get(tx, { id: `1` });
-      assert.equal(mockTx.get.mock.callCount(), 1);
-      assert.deepEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1`]);
+      assert.strictEqual(mockTx.get.mock.callCount(), 1);
+      assert.deepStrictEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1`]);
 
       // Check that a ReadonlyJSONValue is parsed correctly.
       mockTx.get.mock.mockImplementationOnce(() =>
         Promise.resolve({ n: `foo` }),
       );
-      assert.deepEqual(await posts.get(tx, { id: `1` }), { name: `foo` });
+      assert.deepStrictEqual(await posts.get(tx, { id: `1` }), { name: `foo` });
 
       // Check that a value is encoded correctly.
       await posts.set(tx, { id: `1` }, { name: `foo` });
-      assert.equal(mockTx.set.mock.callCount(), 1);
-      assert.deepEqual(mockTx.set.mock.calls[0]?.arguments, [
+      assert.strictEqual(mockTx.set.mock.callCount(), 1);
+      assert.deepStrictEqual(mockTx.set.mock.calls[0]?.arguments, [
         `foo/1`,
         { n: `foo` },
       ]);
@@ -270,8 +270,8 @@ void suite(`rizzle`, () => {
     const { mockTx, tx } = makeMockTx(t);
 
     await posts.get(tx, { id: `1` });
-    assert.equal(mockTx.get.mock.callCount(), 1);
-    assert.deepEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1`]);
+    assert.strictEqual(mockTx.get.mock.callCount(), 1);
+    assert.deepStrictEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1`]);
 
     // Unmarshalling
     {
@@ -284,7 +284,7 @@ void suite(`rizzle`, () => {
         mockTx.get.mock.mockImplementationOnce(() =>
           Promise.resolve({ due: marshaled }),
         );
-        assert.deepEqual(
+        assert.deepStrictEqual(
           await posts.get(tx, { id: `1` }),
           {
             due: unmarshaled,
@@ -302,8 +302,8 @@ void suite(`rizzle`, () => {
         [date.getTime(), date.getTime()], // timestamp as number
       ] as const) {
         await posts.set(tx, { id: `1` }, { due: unmarshaled });
-        assert.equal(mockTx.set.mock.callCount(), 1);
-        assert.deepEqual(mockTx.set.mock.calls[0]?.arguments, [
+        assert.strictEqual(mockTx.set.mock.callCount(), 1);
+        assert.deepStrictEqual(mockTx.set.mock.calls[0]?.arguments, [
           `foo/1`,
           { due: marshaled },
         ]);
@@ -339,7 +339,7 @@ void suite(`rizzle`, () => {
       mockTx.get.mock.mockImplementationOnce(() =>
         Promise.resolve(marshaledData as object),
       );
-      assert.deepEqual(await posts.get(tx, { id: `1` }), {
+      assert.deepStrictEqual(await posts.get(tx, { id: `1` }), {
         skill: skillType,
       });
 
@@ -365,7 +365,7 @@ void suite(`rizzle`, () => {
       mockTx.get.mock.mockImplementationOnce(() =>
         Promise.resolve(marshaledData as object),
       );
-      assert.deepEqual(await posts.get(tx, { id: `1` }), {
+      assert.deepStrictEqual(await posts.get(tx, { id: `1` }), {
         skill,
       });
 
@@ -387,11 +387,11 @@ void suite(`rizzle`, () => {
     mockTx.get.mock.mockImplementationOnce(() =>
       Promise.resolve(marshaledData as object),
     );
-    assert.deepEqual(await posts.get(tx, { id1: `1` }), {
+    assert.deepStrictEqual(await posts.get(tx, { id1: `1` }), {
       text: `hello`,
     });
-    assert.equal(mockTx.get.mock.callCount(), 1);
-    assert.deepEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1`]);
+    assert.strictEqual(mockTx.get.mock.callCount(), 1);
+    assert.deepStrictEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1`]);
 
     mockTx.get.mock.resetCalls();
     mockTx.set.mock.resetCalls();
@@ -411,11 +411,11 @@ void suite(`rizzle`, () => {
     mockTx.get.mock.mockImplementationOnce(() =>
       Promise.resolve(marshaledData as object),
     );
-    assert.deepEqual(await posts.get(tx, { id1: `1`, id2: `2` }), {
+    assert.deepStrictEqual(await posts.get(tx, { id1: `1`, id2: `2` }), {
       text: `hello`,
     });
-    assert.equal(mockTx.get.mock.callCount(), 1);
-    assert.deepEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1/2`]);
+    assert.strictEqual(mockTx.get.mock.callCount(), 1);
+    assert.deepStrictEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/1/2`]);
 
     mockTx.get.mock.resetCalls();
     mockTx.set.mock.resetCalls();
@@ -446,11 +446,13 @@ void suite(`rizzle`, () => {
       mockTx.get.mock.mockImplementationOnce(() =>
         Promise.resolve(marshaledData as object),
       );
-      assert.deepEqual(await posts.get(tx, { skill }), {
+      assert.deepStrictEqual(await posts.get(tx, { skill }), {
         text: `hello`,
       });
-      assert.equal(mockTx.get.mock.callCount(), 1);
-      assert.deepEqual(mockTx.get.mock.calls[0]?.arguments, [`foo/${skillId}`]);
+      assert.strictEqual(mockTx.get.mock.callCount(), 1);
+      assert.deepStrictEqual(mockTx.get.mock.calls[0]?.arguments, [
+        `foo/${skillId}`,
+      ]);
 
       mockTx.get.mock.resetCalls();
       mockTx.set.mock.resetCalls();
@@ -512,7 +514,7 @@ void suite(`rizzle`, () => {
       { author: { name: `foo`, email: `f@o`, id: 1 } },
     );
     const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
-    assert.deepEqual(marshaledData, {
+    assert.deepStrictEqual(marshaledData, {
       author: { name: `foo`, e: `f@o`, i: 1 },
     });
 
@@ -540,7 +542,7 @@ void suite(`rizzle`, () => {
     // Marshal and unmarshal round tripping
     await posts.set(tx, { id: `1` }, { author: { name: `foo` } });
     const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
-    assert.deepEqual(marshaledData, { author: { name: `foo` } });
+    assert.deepStrictEqual(marshaledData, { author: { name: `foo` } });
 
     mockTx.get.mock.mockImplementationOnce(() =>
       Promise.resolve(marshaledData as object),
@@ -562,13 +564,13 @@ void suite(`rizzle`, () => {
         }),
       });
 
-      assert.deepEqual(posts.valueCodec._getIndexes(), {
+      assert.deepStrictEqual(posts.valueCodec._getIndexes(), {
         byAuthorName: {
           allowEmpty: false,
           jsonPointer: `/author/name`,
         },
       });
-      assert.deepEqual(posts.getIndexes(), {
+      assert.deepStrictEqual(posts.getIndexes(), {
         byAuthorName: {
           allowEmpty: false,
           prefix: `foo/`,
@@ -576,17 +578,6 @@ void suite(`rizzle`, () => {
         },
       });
     }
-
-    // set(tx, { id: `1` }, { author: { name: `foo`, email: `f@o` } });
-    // const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
-    // assert.deepEqual(marshaledData, { author: { name: `foo`, e: `f@o` } });
-
-    // mockTx.get.mock.mockImplementationOnce(() =>
-    //   Promise.resolve(marshaledData as object),
-    // );
-    // assert.deepStrictEqual(await posts.get(tx, { id: `1` }), {
-    //   author: { name: `foo`, email: `f@o` },
-    // });
   });
 
   void test(`index scan`, async (t) => {
@@ -600,7 +591,7 @@ void suite(`rizzle`, () => {
     const { mockTx, tx } = makeMockTx(t);
 
     mockTx.scan.mock.mockImplementationOnce((options) => {
-      assert.deepEqual(options, {
+      assert.deepStrictEqual(options, {
         indexName: `byAuthorName`,
         start: undefined,
       });
@@ -612,7 +603,7 @@ void suite(`rizzle`, () => {
       };
     }, 0);
     mockTx.scan.mock.mockImplementationOnce((options) => {
-      assert.deepEqual(options, {
+      assert.deepStrictEqual(options, {
         indexName: `byAuthorName`,
         start: {
           exclusive: true,
@@ -630,7 +621,9 @@ void suite(`rizzle`, () => {
     for await (const post of posts.scan.byAuthorName(tx)) {
       results.push(post);
     }
-    assert.deepEqual(results, [[{ id: `1` }, { author: { name: `brad` } }]]);
+    assert.deepStrictEqual(results, [
+      [{ id: `1` }, { author: { name: `brad` } }],
+    ]);
 
     typeChecks(async () => {
       const posts = rizzle.schema(`foo/[id]`, {
@@ -641,7 +634,7 @@ void suite(`rizzle`, () => {
           })
           .alias(`a`),
       });
-      assert.deepEqual(posts.getIndexes(), {
+      assert.deepStrictEqual(posts.getIndexes(), {
         byAuthorName: {
           allowEmpty: false,
           prefix: `foo/`,
@@ -659,10 +652,10 @@ void suite(`rizzle`, () => {
   });
 
   void test(`parseKeyPath`, () => {
-    assert.deepEqual(parseKeyPath(`foo/$[id]`, `foo/$1`), { id: `1` });
-    assert.deepEqual(parseKeyPath(`^foo/$[id]`, `^foo/$1`), { id: `1` });
-    assert.deepEqual(parseKeyPath(`foo/[id]`, `foo/1`), { id: `1` });
-    assert.deepEqual(parseKeyPath(`foo/[id1]/[id2]`, `foo/1/2`), {
+    assert.deepStrictEqual(parseKeyPath(`foo/$[id]`, `foo/$1`), { id: `1` });
+    assert.deepStrictEqual(parseKeyPath(`^foo/$[id]`, `^foo/$1`), { id: `1` });
+    assert.deepStrictEqual(parseKeyPath(`foo/[id]`, `foo/1`), { id: `1` });
+    assert.deepStrictEqual(parseKeyPath(`foo/[id1]/[id2]`, `foo/1/2`), {
       id1: `1`,
       id2: `2`,
     });
@@ -679,7 +672,7 @@ void suite(`rizzle`, () => {
     // Marshal and unmarshal round tripping
     await posts.set(tx, { id: `1` }, { count: 5 });
     const [, marshaledData] = mockTx.set.mock.calls[0]!.arguments;
-    assert.deepEqual(marshaledData, { c: 5 });
+    assert.deepStrictEqual(marshaledData, { c: 5 });
 
     mockTx.get.mock.mockImplementationOnce(() =>
       Promise.resolve(marshaledData as object),

--- a/projects/app/src/__tests__/dictionary/dictionary.test.ts
+++ b/projects/app/src/__tests__/dictionary/dictionary.test.ts
@@ -70,7 +70,7 @@ void test(`there are no pronunciations mixed into word definitions`, async () =>
 
 void test(`there are 214 radicals to match official kangxi radicals`, async () => {
   const radicals = await loadRadicals();
-  assert.equal(radicals.length, 214);
+  assert.strictEqual(radicals.length, 214);
 });
 
 void test(`radical name mnemonics don't include radical alternatives`, async () => {
@@ -79,7 +79,10 @@ void test(`radical name mnemonics don't include radical alternatives`, async () 
 
   const radicalsWithNameMnemonics = new Set(radicalNameMnemonics.keys());
 
-  assert.deepEqual(radicalsWithNameMnemonics.difference(primarySet), new Set());
+  assert.deepStrictEqual(
+    radicalsWithNameMnemonics.difference(primarySet),
+    new Set(),
+  );
 });
 
 void test(`radical pinyin mnemonics don't include radical alternatives`, async () => {
@@ -88,7 +91,10 @@ void test(`radical pinyin mnemonics don't include radical alternatives`, async (
 
   const radicalsWithNameMnemonics = new Set(pinyinMnemonics.keys());
 
-  assert.deepEqual(radicalsWithNameMnemonics.difference(primarySet), new Set());
+  assert.deepStrictEqual(
+    radicalsWithNameMnemonics.difference(primarySet),
+    new Set(),
+  );
 });
 
 void test(`radical data uses consistent unicode characters`, async () => {
@@ -97,7 +103,7 @@ void test(`radical data uses consistent unicode characters`, async () => {
 
   {
     const violations = primary.filter(isNotCjkUnifiedIdeograph);
-    assert.deepEqual(
+    assert.deepStrictEqual(
       violations,
       [],
       await debugNonCjkUnifiedIdeographs(violations),
@@ -106,8 +112,8 @@ void test(`radical data uses consistent unicode characters`, async () => {
 
   {
     const sample = [...(await loadRadicalNameMnemonics()).keys()];
-    assert.deepEqual(new Set(sample).difference(primarySet), new Set());
-    assert.deepEqual(sample.filter(isNotCjkUnifiedIdeograph), []);
+    assert.deepStrictEqual(new Set(sample).difference(primarySet), new Set());
+    assert.deepStrictEqual(sample.filter(isNotCjkUnifiedIdeograph), []);
   }
 
   {
@@ -117,13 +123,13 @@ void test(`radical data uses consistent unicode characters`, async () => {
 
     {
       const diff = new Set(sample).difference(primarySet);
-      assert.deepEqual(
+      assert.deepStrictEqual(
         diff,
         new Set(),
         await debugNonCjkUnifiedIdeographs([...diff]),
       );
     }
-    assert.deepEqual([...sample].filter(isNotCjkUnifiedIdeograph), []);
+    assert.deepStrictEqual([...sample].filter(isNotCjkUnifiedIdeograph), []);
   }
 });
 
@@ -190,7 +196,7 @@ void test(`convertPinyinWithToneNumberToToneMark`, () => {
     [`zhu5`, `zhu`],
     [`zi5`, `zi`],
   ] as const) {
-    assert.equal(convertPinyinWithToneNumberToToneMark(input), expected);
+    assert.strictEqual(convertPinyinWithToneNumberToToneMark(input), expected);
   }
 });
 
@@ -201,7 +207,7 @@ void test(`flattenIds handles ⿱⿱ to ⿳ and ⿰⿰ to ⿲`, () => {
     [`⿰⿰abc`, `⿲abc`],
     [`⿰a⿰bc`, `⿲abc`],
   ] as const) {
-    assert.equal(idsNodeToString(flattenIds(parseIds(input))), expected);
+    assert.strictEqual(idsNodeToString(flattenIds(parseIds(input))), expected);
   }
 });
 
@@ -268,7 +274,7 @@ async function testPinyinChart(
 
   // Start with test cases first as these are easier to debug.
   for (const [input, initial, final] of testCases) {
-    assert.deepEqual(
+    assert.deepStrictEqual(
       splitPinyin(input, chart),
       [initial, final],
       `${input} didn't split as expected`,
@@ -296,7 +302,7 @@ function assertUniqueArray<T>(items: readonly T[]): void {
       duplicates.push(x);
     }
   }
-  assert.deepEqual(duplicates, [], `expected no duplicates`);
+  assert.deepStrictEqual(duplicates, [], `expected no duplicates`);
 }
 
 void test(`standard pinyin covers kangxi pinyin`, async () => {
@@ -413,8 +419,8 @@ void test(`hh pinyin covers kangxi pinyin`, async () => {
 void test(`hmm pinyin covers kangxi pinyin`, async () => {
   const chart = await loadHmmPinyinChart();
 
-  assert.equal(chart.initials.flatMap((i) => i.initials).length, 55);
-  assert.equal(chart.finals.length, 13);
+  assert.strictEqual(chart.initials.flatMap((i) => i.initials).length, 55);
+  assert.strictEqual(chart.finals.length, 13);
 
   await testPinyinChart(chart, [
     [`a`, `∅`, `a`],
@@ -440,24 +446,27 @@ void test(`hmm pinyin covers kangxi pinyin`, async () => {
 });
 
 void test(`parseIds handles 1 depth`, () => {
-  assert.deepEqual(parseIds(`木`), { type: `LeafCharacter`, character: `木` });
+  assert.deepStrictEqual(parseIds(`木`), {
+    type: `LeafCharacter`,
+    character: `木`,
+  });
 
   // 相
-  assert.deepEqual(parseIds(`⿰木目`), {
+  assert.deepStrictEqual(parseIds(`⿰木目`), {
     type: IdsOperator.LeftToRight,
     left: { type: `LeafCharacter`, character: `木` },
     right: { type: `LeafCharacter`, character: `目` },
   });
 
   // 杏
-  assert.deepEqual(parseIds(`⿱木口`), {
+  assert.deepStrictEqual(parseIds(`⿱木口`), {
     type: IdsOperator.AboveToBelow,
     above: { type: `LeafCharacter`, character: `木` },
     below: { type: `LeafCharacter`, character: `口` },
   });
 
   // 衍
-  assert.deepEqual(parseIds(`⿲彳氵亍`), {
+  assert.deepStrictEqual(parseIds(`⿲彳氵亍`), {
     type: IdsOperator.LeftToMiddleToRight,
     left: { type: `LeafCharacter`, character: `彳` },
     middle: { type: `LeafCharacter`, character: `氵` },
@@ -465,7 +474,7 @@ void test(`parseIds handles 1 depth`, () => {
   });
 
   // 京
-  assert.deepEqual(parseIds(`⿳亠口小`), {
+  assert.deepStrictEqual(parseIds(`⿳亠口小`), {
     type: IdsOperator.AboveToMiddleAndBelow,
     above: { type: `LeafCharacter`, character: `亠` },
     middle: { type: `LeafCharacter`, character: `口` },
@@ -473,183 +482,183 @@ void test(`parseIds handles 1 depth`, () => {
   });
 
   // 回
-  assert.deepEqual(parseIds(`⿴囗口`), {
+  assert.deepStrictEqual(parseIds(`⿴囗口`), {
     type: IdsOperator.FullSurround,
     surrounding: { type: `LeafCharacter`, character: `囗` },
     surrounded: { type: `LeafCharacter`, character: `口` },
   });
 
   // 凰
-  assert.deepEqual(parseIds(`⿵几皇`), {
+  assert.deepStrictEqual(parseIds(`⿵几皇`), {
     type: IdsOperator.SurroundFromAbove,
     above: { type: `LeafCharacter`, character: `几` },
     surrounded: { type: `LeafCharacter`, character: `皇` },
   });
 
   // 凶
-  assert.deepEqual(parseIds(`⿶凵㐅`), {
+  assert.deepStrictEqual(parseIds(`⿶凵㐅`), {
     type: IdsOperator.SurroundFromBelow,
     below: { type: `LeafCharacter`, character: `凵` },
     surrounded: { type: `LeafCharacter`, character: `㐅` },
   });
 
   // 匠
-  assert.deepEqual(parseIds(`⿷匚斤`), {
+  assert.deepStrictEqual(parseIds(`⿷匚斤`), {
     type: IdsOperator.SurroundFromLeft,
     left: { type: `LeafCharacter`, character: `匚` },
     surrounded: { type: `LeafCharacter`, character: `斤` },
   });
 
   // 㕚
-  assert.deepEqual(parseIds(`⿼叉丶`), {
+  assert.deepStrictEqual(parseIds(`⿼叉丶`), {
     type: IdsOperator.SurroundFromRight,
     right: { type: `LeafCharacter`, character: `叉` },
     surrounded: { type: `LeafCharacter`, character: `丶` },
   });
 
   // 病
-  assert.deepEqual(parseIds(`⿸疒丙`), {
+  assert.deepStrictEqual(parseIds(`⿸疒丙`), {
     type: IdsOperator.SurroundFromUpperLeft,
     upperLeft: { type: `LeafCharacter`, character: `疒` },
     surrounded: { type: `LeafCharacter`, character: `丙` },
   });
 
   // 戒
-  assert.deepEqual(parseIds(`⿹戈廾`), {
+  assert.deepStrictEqual(parseIds(`⿹戈廾`), {
     type: IdsOperator.SurroundFromUpperRight,
     upperRight: { type: `LeafCharacter`, character: `戈` },
     surrounded: { type: `LeafCharacter`, character: `廾` },
   });
 
   // 超
-  assert.deepEqual(parseIds(`⿺走召`), {
+  assert.deepStrictEqual(parseIds(`⿺走召`), {
     type: IdsOperator.SurroundFromLowerLeft,
     lowerLeft: { type: `LeafCharacter`, character: `走` },
     surrounded: { type: `LeafCharacter`, character: `召` },
   });
 
   // 氷
-  assert.deepEqual(parseIds(`⿽水丶`), {
+  assert.deepStrictEqual(parseIds(`⿽水丶`), {
     type: IdsOperator.SurroundFromLowerRight,
     lowerRight: { type: `LeafCharacter`, character: `水` },
     surrounded: { type: `LeafCharacter`, character: `丶` },
   });
 
   // 巫
-  assert.deepEqual(parseIds(`⿻工从`), {
+  assert.deepStrictEqual(parseIds(`⿻工从`), {
     type: IdsOperator.Overlaid,
     overlay: { type: `LeafCharacter`, character: `工` },
     underlay: { type: `LeafCharacter`, character: `从` },
   });
 
   // 卐
-  assert.deepEqual(parseIds(`⿾卍`), {
+  assert.deepStrictEqual(parseIds(`⿾卍`), {
     type: IdsOperator.HorizontalReflection,
     reflected: { type: `LeafCharacter`, character: `卍` },
   });
 
   // 𠕄
-  assert.deepEqual(parseIds(`⿿凹`), {
+  assert.deepStrictEqual(parseIds(`⿿凹`), {
     type: IdsOperator.Rotation,
     rotated: { type: `LeafCharacter`, character: `凹` },
   });
 
-  assert.deepEqual(parseIds(`①`), {
+  assert.deepStrictEqual(parseIds(`①`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 1,
   });
 
-  assert.deepEqual(parseIds(`②`), {
+  assert.deepStrictEqual(parseIds(`②`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 2,
   });
 
-  assert.deepEqual(parseIds(`③`), {
+  assert.deepStrictEqual(parseIds(`③`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 3,
   });
 
-  assert.deepEqual(parseIds(`④`), {
+  assert.deepStrictEqual(parseIds(`④`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 4,
   });
 
-  assert.deepEqual(parseIds(`⑤`), {
+  assert.deepStrictEqual(parseIds(`⑤`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 5,
   });
 
-  assert.deepEqual(parseIds(`⑥`), {
+  assert.deepStrictEqual(parseIds(`⑥`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 6,
   });
 
-  assert.deepEqual(parseIds(`⑦`), {
+  assert.deepStrictEqual(parseIds(`⑦`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 7,
   });
 
-  assert.deepEqual(parseIds(`⑧`), {
+  assert.deepStrictEqual(parseIds(`⑧`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 8,
   });
 
-  assert.deepEqual(parseIds(`⑨`), {
+  assert.deepStrictEqual(parseIds(`⑨`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 9,
   });
 
-  assert.deepEqual(parseIds(`⑩`), {
+  assert.deepStrictEqual(parseIds(`⑩`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 10,
   });
 
-  assert.deepEqual(parseIds(`⑪`), {
+  assert.deepStrictEqual(parseIds(`⑪`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 11,
   });
 
-  assert.deepEqual(parseIds(`⑫`), {
+  assert.deepStrictEqual(parseIds(`⑫`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 12,
   });
 
-  assert.deepEqual(parseIds(`⑬`), {
+  assert.deepStrictEqual(parseIds(`⑬`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 13,
   });
 
-  assert.deepEqual(parseIds(`⑭`), {
+  assert.deepStrictEqual(parseIds(`⑭`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 14,
   });
 
-  assert.deepEqual(parseIds(`⑮`), {
+  assert.deepStrictEqual(parseIds(`⑮`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 15,
   });
 
-  assert.deepEqual(parseIds(`⑯`), {
+  assert.deepStrictEqual(parseIds(`⑯`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 16,
   });
 
-  assert.deepEqual(parseIds(`⑰`), {
+  assert.deepStrictEqual(parseIds(`⑰`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 17,
   });
 
-  assert.deepEqual(parseIds(`⑱`), {
+  assert.deepStrictEqual(parseIds(`⑱`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 18,
   });
 
-  assert.deepEqual(parseIds(`⑲`), {
+  assert.deepStrictEqual(parseIds(`⑲`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 19,
   });
 
-  assert.deepEqual(parseIds(`⑳`), {
+  assert.deepStrictEqual(parseIds(`⑳`), {
     type: `LeafUnknownCharacter`,
     strokeCount: 20,
   });
@@ -658,7 +667,7 @@ void test(`parseIds handles 1 depth`, () => {
 void test(`parseIds handles 2 depth`, () => {
   {
     const cursor = { index: 0 };
-    assert.deepEqual(parseIds(`⿰a⿱bc`, cursor), {
+    assert.deepStrictEqual(parseIds(`⿰a⿱bc`, cursor), {
       type: IdsOperator.LeftToRight,
       left: { type: `LeafCharacter`, character: `a` },
       right: {
@@ -667,12 +676,12 @@ void test(`parseIds handles 2 depth`, () => {
         below: { type: `LeafCharacter`, character: `c` },
       },
     });
-    assert.deepEqual(cursor, { index: 5 });
+    assert.deepStrictEqual(cursor, { index: 5 });
   }
 
   {
     const cursor = { index: 0 };
-    assert.deepEqual(parseIds(`⿱a⿳bc⿴de`, cursor), {
+    assert.deepStrictEqual(parseIds(`⿱a⿳bc⿴de`, cursor), {
       type: IdsOperator.AboveToBelow,
       above: { type: `LeafCharacter`, character: `a` },
       below: {
@@ -686,7 +695,7 @@ void test(`parseIds handles 2 depth`, () => {
         },
       },
     });
-    assert.deepEqual(cursor, { index: 8 });
+    assert.deepStrictEqual(cursor, { index: 8 });
   }
 });
 
@@ -702,7 +711,7 @@ void test(`walkIdsNode`, () => {
     }
   });
 
-  assert.deepEqual(leafs, [`a`, `b`, `c`]);
+  assert.deepStrictEqual(leafs, [`a`, `b`, `c`]);
 });
 
 void test(`idsNodeToString roundtrips`, () => {
@@ -719,7 +728,7 @@ void test(`idsNodeToString roundtrips`, () => {
     [`①`, `②`, `③`, `④`, `⑤`, `⑥`, `⑦`, `⑧`, `⑨`, `⑩`],
     [`⑪`, `⑫`, `⑬`, `⑭`, `⑮`, `⑯`, `⑰`, `⑱`, `⑲`, `⑳`],
   ].flatMap((x) => x)) {
-    assert.equal(idsNodeToString(parseIds(input)), input);
+    assert.strictEqual(idsNodeToString(parseIds(input)), input);
   }
 });
 

--- a/projects/app/src/__tests__/util/collections.test.ts
+++ b/projects/app/src/__tests__/util/collections.test.ts
@@ -21,13 +21,13 @@ void test(`sortComparatorString`, () => {
   {
     const arr = [`c`, `a`, `b`];
     arr.sort(sortComparatorString());
-    assert.deepEqual(arr, [`a`, `b`, `c`]);
+    assert.deepStrictEqual(arr, [`a`, `b`, `c`]);
   }
 
   {
     const arr = [[`c`], [`a`], [`b`]];
     arr.sort(sortComparatorString(([x]) => x!));
-    assert.deepEqual(arr, [[`a`], [`b`], [`c`]]);
+    assert.deepStrictEqual(arr, [[`a`], [`b`], [`c`]]);
   }
 });
 
@@ -35,29 +35,29 @@ void test(`sortComparatorNumber`, () => {
   {
     const arr = [3, 1, 2];
     arr.sort(sortComparatorNumber());
-    assert.deepEqual(arr, [1, 2, 3]);
+    assert.deepStrictEqual(arr, [1, 2, 3]);
   }
 
   {
     const arr = [[3], [1], [2]];
     arr.sort(sortComparatorNumber(([x]) => x!));
-    assert.deepEqual(arr, [[1], [2], [3]]);
+    assert.deepStrictEqual(arr, [[1], [2], [3]]);
   }
 });
 
 void test(`merge`, () => {
-  assert.deepEqual(merge(null, null), null);
-  assert.deepEqual(merge(null, 1), 1);
-  assert.deepEqual(merge(1, null), 1);
-  assert.deepEqual(merge([1], [2]), [1, 2]);
-  assert.deepEqual(
+  assert.deepStrictEqual(merge(null, null), null);
+  assert.deepStrictEqual(merge(null, 1), 1);
+  assert.deepStrictEqual(merge(1, null), 1);
+  assert.deepStrictEqual(merge([1], [2]), [1, 2]);
+  assert.deepStrictEqual(
     merge(new Map([[`key1`, `value1`]]), new Map([[`key2`, `value2`]])),
     new Map([
       [`key1`, `value1`],
       [`key2`, `value2`],
     ]),
   );
-  assert.deepEqual(
+  assert.deepStrictEqual(
     merge(
       new Map([[`key1`, new Map([[`key1.1`, `value1.1`]])]]),
       new Map([[`key1`, new Map([[`key2.1`, `value2.1`]])]]),
@@ -75,11 +75,11 @@ void test(`merge`, () => {
 });
 
 void test(`deepTransform`, () => {
-  assert.deepEqual(
+  assert.deepStrictEqual(
     deepTransform(null, (x) => x),
     null,
   );
-  assert.deepEqual(
+  assert.deepStrictEqual(
     deepTransform(new Map([[`key1`, `value1`]]), (x) =>
       x instanceof Map ? Object.fromEntries(x.entries()) : x,
     ),
@@ -88,13 +88,13 @@ void test(`deepTransform`, () => {
 });
 
 void test(`objectInvert`, () => {
-  assert.deepEqual(objectInvert({}), {});
-  assert.deepEqual(objectInvert({ a: 1, b: 2 }), { 1: `a`, 2: `b` });
+  assert.deepStrictEqual(objectInvert({}), {});
+  assert.deepStrictEqual(objectInvert({ a: 1, b: 2 }), { 1: `a`, 2: `b` });
 });
 
 void test(`mapInvert`, () => {
-  assert.deepEqual(mapInvert(new Map()), new Map());
-  assert.deepEqual(
+  assert.deepStrictEqual(mapInvert(new Map()), new Map());
+  assert.deepStrictEqual(
     mapInvert(
       new Map<string | number, string | number>([
         [1, 2],

--- a/projects/app/src/data/marshal.ts
+++ b/projects/app/src/data/marshal.ts
@@ -872,7 +872,8 @@ export const buildKeyPathRegex = <T extends string>(keyPath: T) => {
   return (input: string) => {
     const result = regex.exec(input)?.groups;
     invariant(result != null, `couldn't parse key ${input} using ${keyPath}`);
-    return result as Record<ExtractVariableNames<T>, string>;
+    // fix the prototype
+    return { ...result } as Record<ExtractVariableNames<T>, string>;
   };
 };
 export type Timestamp = number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2768,7 +2768,7 @@ __metadata:
     react-native-svg: "npm:15.8.0"
     react-native-web: "npm:^0.19.13"
     react-responsive: "npm:^10.0.0"
-    replicache: "npm:^14.2.2"
+    replicache: "patch:replicache@patch%3Areplicache@npm%253A14.2.2%23~/.yarn/patches/replicache-npm-14.2.2-d99f6a2b5c.patch%3A%3Aversion=14.2.2&hash=f2490e#~/.yarn/patches/replicache-patch-e568419bdf.patch"
     replicache-react: "npm:^5.0.1"
     tailwind-variants: "npm:^0.2.1"
     tailwindcss: "npm:^3.4.14"
@@ -15982,7 +15982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"replicache@npm:^14.2.2":
+"replicache@npm:14.2.2":
   version: 14.2.2
   resolution: "replicache@npm:14.2.2"
   dependencies:
@@ -15993,6 +15993,34 @@ __metadata:
   bin:
     replicache: out/cli.cjs
   checksum: 10c0/6448b6b68a249044ad9be6077a7b2537f9e67e0400b20e2ea7bd5354337b1aaad36b6ff616150259ae13686d65039e0385d06d09f75e291703af77f1bdc462fa
+  languageName: node
+  linkType: hard
+
+"replicache@patch:replicache@npm%3A14.2.2#~/.yarn/patches/replicache-npm-14.2.2-d99f6a2b5c.patch::version=14.2.2&hash=f2490e":
+  version: 14.2.2
+  resolution: "replicache@patch:replicache@npm%3A14.2.2#~/.yarn/patches/replicache-npm-14.2.2-d99f6a2b5c.patch::version=14.2.2&hash=f2490e"
+  dependencies:
+    "@badrap/valita": "npm:^0.3.0"
+    "@rocicorp/lock": "npm:^1.0.3"
+    "@rocicorp/logger": "npm:^5.2.1"
+    "@rocicorp/resolver": "npm:^1.0.1"
+  bin:
+    replicache: out/cli.cjs
+  checksum: 10c0/ab9d1746c7daf8de309c8c4fd55c252246fb2c92d9c2bebaa045f0af3415911c655b754d75400a6c08c17e7a0662cbdc5915da97deb01e5f90f0f8793be35bfc
+  languageName: node
+  linkType: hard
+
+"replicache@patch:replicache@patch%3Areplicache@npm%253A14.2.2%23~/.yarn/patches/replicache-npm-14.2.2-d99f6a2b5c.patch%3A%3Aversion=14.2.2&hash=f2490e#~/.yarn/patches/replicache-patch-e568419bdf.patch":
+  version: 14.2.2
+  resolution: "replicache@patch:replicache@patch%3Areplicache@npm%253A14.2.2%23~/.yarn/patches/replicache-npm-14.2.2-d99f6a2b5c.patch%3A%3Aversion=14.2.2&hash=f2490e#~/.yarn/patches/replicache-patch-e568419bdf.patch::version=14.2.2&hash=58fef1"
+  dependencies:
+    "@badrap/valita": "npm:^0.3.0"
+    "@rocicorp/lock": "npm:^1.0.3"
+    "@rocicorp/logger": "npm:^5.2.1"
+    "@rocicorp/resolver": "npm:^1.0.1"
+  bin:
+    replicache: out/cli.cjs
+  checksum: 10c0/79c315c1be60c096f11df7c89d4e1a355785fdacf34d4c4009bfb59ea4ded0f7f023177647f0df0e584e548bfe8808c0e978113f4ffd75cea8153f6a035770de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request focuses on improving the assertions in the test files by replacing `assert.equal` and `assert.deepEqual` with `assert.strictEqual` and `assert.deepStrictEqual`, respectively. These changes ensure that the tests perform strict equality checks, which can help catch subtle bugs.

### Changes in `projects/app/src/__tests__/data/marshal.test.ts`:

* Replaced `assert.equal` with `assert.strictEqual` to enforce strict equality checks. [[1]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL150-R162) [[2]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL195-R207) [[3]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL273-R274) [[4]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL305-R306) [[5]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL390-R394) [[6]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL414-R418) [[7]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL449-R455) [[8]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L193-R199) [[9]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L204-R210) [[10]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L416-R423)
* Replaced `assert.deepEqual` with `assert.deepStrictEqual` to enforce deep strict equality checks. [[1]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL150-R162) [[2]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL195-R207) [[3]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL287-R287) [[4]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL342-R342) [[5]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL368-R368) [[6]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL414-R418) [[7]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL449-R455) [[8]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL515-R517) [[9]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL543-R545) [[10]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL565-L589) [[11]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL603-R594) [[12]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL615-R606) [[13]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL633-R626) [[14]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL644-R637) [[15]](diffhunk://#diff-473bcc9c6988444358d164ec950dd822f946e97e1759531f4e5dca392dc9483eL662-R658)

### Changes in `projects/app/src/__tests__/dictionary/dictionary.test.ts`:

* Replaced `assert.equal` with `assert.strictEqual` to enforce strict equality checks. [[1]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L73-R73) [[2]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L193-R199) [[3]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L204-R210) [[4]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L416-R423)
* Replaced `assert.deepEqual` with `assert.deepStrictEqual` to enforce deep strict equality checks. [[1]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L82-R85) [[2]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L91-R97) [[3]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L100-R106) [[4]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L109-R116) [[5]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L120-R132) [[6]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L271-R277) [[7]](diffhunk://#diff-1cdf951cb749b61fcfbce64e83b7a5695f6861dceef11bfa6eb5b916adee0e54L299-R305)

These changes will help ensure that the tests are more robust and catch potential issues related to type coercion.