### PR TITLE
Add .literal() .nullable()

### DIFF
--- a/projects/app/src/__tests__/data/rizzle.test.ts
+++ b/projects/app/src/__tests__/data/rizzle.test.ts
@@ -5,10 +5,13 @@ import {
   r,
   RizzleIndexed,
   RizzleIndexNames,
+  RizzleNullable,
   RizzleObject,
   RizzleObjectInput,
+  RizzleObjectMarshaled,
   RizzleObjectOutput,
   RizzlePrimitive,
+  RizzleReplicache,
   RizzleReplicacheMutators,
   RizzleReplicacheQuery,
   RizzleTypeAlias,
@@ -25,7 +28,6 @@ import {
   TEST_LICENSE_KEY,
   WriteTransaction,
 } from "replicache";
-import { Prettify } from "ts-essentials";
 import { z } from "zod";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-parameters
@@ -109,6 +111,73 @@ void test(`string() key and value`, async (t) => {
     void posts.set(tx, { id: `1` }, { name: `foo` });
     // @ts-expect-error `id` is the key, not `name`
     void posts.set(tx, { name: `1` }, { name: `foo` });
+  });
+});
+
+void test(`string() .nullable()`, async (t) => {
+  const posts = r.keyValue(`foo/[id]`, {
+    id: r.string(),
+    name: r.string().nullable().alias(`n`),
+  });
+
+  using tx = makeMockTx(t);
+
+  tx.get.mock.mockImplementationOnce(async () => ({ n: `foo` }));
+  assert.deepEqual(await posts.get(tx, { id: `1` }), { name: `foo` });
+
+  tx.get.mock.mockImplementationOnce(async () => ({ n: null }));
+  assert.deepEqual(await posts.get(tx, { id: `1` }), { name: null });
+
+  typeChecks(async () => {
+    // .get()
+    {
+      const x = await posts.get(tx, { id: `1` });
+      true satisfies IsEqual<typeof x, { name: string | null } | undefined>;
+    }
+
+    // .set()
+    void posts.set(tx, { id: `1` }, { name: `foo` });
+    void posts.set(tx, { id: `1` }, { name: null });
+  });
+});
+
+void test(`object() .nullable()`, async (t) => {
+  const posts = r.keyValue(`foo/[id]`, {
+    id: r.string(),
+    name: r
+      .object({
+        first: r.string(),
+        last: r.string(),
+      })
+      .nullable()
+      .alias(`n`),
+  });
+
+  using tx = makeMockTx(t);
+
+  tx.get.mock.mockImplementationOnce(async () => ({
+    n: { first: `a`, last: `b` },
+  }));
+  assert.deepEqual(await posts.get(tx, { id: `1` }), {
+    name: { first: `a`, last: `b` },
+  });
+
+  tx.get.mock.mockImplementationOnce(async () => ({ n: null }));
+  assert.deepEqual(await posts.get(tx, { id: `1` }), { name: null });
+
+  typeChecks(async () => {
+    // .get()
+    {
+      const x = await posts.get(tx, { id: `1` });
+      true satisfies IsEqual<
+        typeof x,
+        { name: { first: string; last: string } | null } | undefined
+      >;
+    }
+
+    // .set()
+    void posts.set(tx, { id: `1` }, { name: { first: `a`, last: `b` } });
+    void posts.set(tx, { id: `1` }, { name: null });
   });
 });
 
@@ -256,6 +325,15 @@ void test(`keyValue() one variable`, async (t) => {
   assert.deepEqual(tx.get.mock.calls[0]?.arguments, [`foo/1`]);
 });
 
+void test(`keyValue() variables requires string marshaler`, async () => {
+  typeChecks(() => {
+    r.keyValue(`foo/[id]`, { id: r.string() });
+    r.keyValue(`foo/[id]`, { id: r.literal(`foo`, r.string()) });
+    // @ts-expect-error number() doesn't marshal to a string
+    r.keyValue(`foo/[id]`, { id: r.number() });
+  });
+});
+
 void test(`keyValue() two variables`, async (t) => {
   const posts = r.keyValue(`foo/[id1]/[id2]`, {
     id1: r.string(),
@@ -275,35 +353,8 @@ void test(`keyValue() two variables`, async (t) => {
   assert.deepEqual(tx.get.mock.calls[0]?.arguments, [`foo/1/2`]);
 });
 
-typeChecks(`keyValue() requires variables to be declared`, () => {
-  r.keyValue(
-    `foo/[id]`,
-    // @ts-expect-error `id` is missing
-    { text: r.string() },
-  );
-});
-
-void test(`number()`, async (t) => {
-  const posts = r.keyValue(`foo/[id]`, {
-    id: r.string(),
-    count: r.number(`c`),
-  });
-
-  using tx = makeMockTx(t);
-
-  // Marshal and unmarshal round tripping
-  await posts.set(tx, { id: `1` }, { count: 5 });
-  const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
-  assert.deepEqual(marshaledData, { c: 5 });
-
-  tx.get.mock.mockImplementationOnce(async () => marshaledData);
-  assert.deepEqual(await posts.get(tx, { id: `1` }), {
-    count: 5,
-  });
-});
-
 void test(`keyValue() non-string key codec`, async (t) => {
-  const rComplex = r.zod(
+  const rComplex = r.primitive(
     z
       .tuple([z.string(), z.number()])
       .readonly()
@@ -352,6 +403,79 @@ void test(`keyValue() .has()`, async (t) => {
   assert.deepEqual(await posts.has(tx, { id: `2` }), false);
 });
 
+void test(`keyValue() distinguishing between input/output types`, async (t) => {
+  const rCoerciveString = () =>
+    r.primitive(
+      // takes in a number or string
+      z
+        .union([z.number(), z.string()])
+        .transform((v) => (typeof v === `string` ? v : v.toString())),
+      // but always returns back to a string
+      z.string(),
+    );
+
+  const posts = r.keyValue(`foo/[id]`, {
+    id: rCoerciveString(),
+    text: rCoerciveString().indexed(`byText`),
+  });
+
+  using tx = makeMockTx(t);
+
+  // .get()
+  {
+    const x1 = await posts.get(tx, { id: `1` });
+    true satisfies IsEqual<typeof x1, { text: string } | undefined>;
+    const x2 = await posts.get(tx, { id: 1 });
+    true satisfies IsEqual<typeof x2, { text: string } | undefined>;
+  }
+
+  // .has()
+  await posts.has(tx, { id: `1` });
+  await posts.has(tx, { id: 1 });
+
+  // .set()
+  await posts.set(tx, { id: `1` }, { text: `1` });
+  await posts.set(tx, { id: 1 }, { text: 1 });
+
+  // index scan
+  typeChecks(async () => {
+    const schema = { posts };
+    const r = null as unknown as RizzleReplicache<typeof schema>;
+    for await (const [key, value] of r.query.posts.byText(tx)) {
+      true satisfies IsEqual<typeof key, { id: string }>;
+      true satisfies IsEqual<typeof value, { text: string }>;
+    }
+  });
+});
+
+void test(`keyValue() requires variables to be declared`, () => {
+  typeChecks(() => {
+    r.keyValue(
+      `foo/[id]`,
+      // @ts-expect-error `id` is missing
+      { text: r.string() },
+    );
+  });
+});
+
+void test(`number()`, async (t) => {
+  const posts = r.keyValue(`foo/[id]`, {
+    id: r.string(),
+    count: r.number(`c`),
+  });
+
+  using tx = makeMockTx(t);
+
+  // Marshal and unmarshal round tripping
+  await posts.set(tx, { id: `1` }, { count: 5 });
+  const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
+  assert.deepEqual(marshaledData, { c: 5 });
+
+  tx.get.mock.mockImplementationOnce(async () => marshaledData);
+  assert.deepEqual(await posts.get(tx, { id: `1` }), {
+    count: 5,
+  });
+});
 void test(`enum()`, async (t) => {
   enum Colors {
     RED,
@@ -433,9 +557,27 @@ void test(`object()`, async (t) => {
   });
 });
 
-void test(`object indexes`, () => {
+void test(`.getIndexes()`, () => {
+  // no key path variables
   {
-    const posts = r.keyValue(`foo/[id]`, {
+    const posts = r.keyValue(`foo`, {
+      id: r.string(),
+      author: r.object({
+        name: r.string().indexed(`byAuthorName`),
+      }),
+    });
+    assert.deepEqual(posts.getIndexes(), {
+      byAuthorName: {
+        allowEmpty: false,
+        prefix: `foo`,
+        jsonPointer: `/author/name`,
+      },
+    });
+  }
+
+  // object(.string().indexed())
+  {
+    const posts = r.keyValue(`foo/`, {
       id: r.string(),
       author: r.object({
         name: r.string().indexed(`byAuthorName`),
@@ -456,9 +598,57 @@ void test(`object indexes`, () => {
       },
     });
   }
+
+  // .string().indexed().nullable()
+  {
+    const posts = r.keyValue(`foo/[id]`, {
+      id: r.string(),
+      name: r.string().indexed(`byAuthorName`).nullable(),
+    });
+
+    assert.deepEqual(posts.getIndexes(), {
+      byAuthorName: {
+        allowEmpty: false,
+        prefix: `foo/`,
+        jsonPointer: `/name`,
+      },
+    });
+  }
+
+  // .string().alias().indexed().nullable()
+  {
+    const posts = r.keyValue(`foo/[id]`, {
+      id: r.string(),
+      name: r.string().alias(`n`).indexed(`byAuthorName`).nullable(),
+    });
+
+    assert.deepEqual(posts.getIndexes(), {
+      byAuthorName: {
+        allowEmpty: false,
+        prefix: `foo/`,
+        jsonPointer: `/n`,
+      },
+    });
+  }
+
+  // .string().indexed().alias()
+  {
+    const posts = r.keyValue(`foo/[id]`, {
+      id: r.string(),
+      name: r.string().indexed(`byAuthorName`).alias(`n`),
+    });
+
+    assert.deepEqual(posts.getIndexes(), {
+      byAuthorName: {
+        allowEmpty: false,
+        prefix: `foo/`,
+        jsonPointer: `/n`,
+      },
+    });
+  }
 });
 
-void test(`parseKeyPath`, () => {
+void test(`${parseKeyPath.name}()`, () => {
   assert.deepEqual(parseKeyPath(`foo/$[id]`, `foo/$1`), { id: `1` });
   assert.deepEqual(parseKeyPath(`^foo/$[id]`, `^foo/$1`), { id: `1` });
   assert.deepEqual(parseKeyPath(`foo/[id]`, `foo/1`), { id: `1` });
@@ -479,6 +669,70 @@ void test(`mutator()`, async () => {
   assert.deepEqual(fn._def.alias, `cp`);
 });
 
+typeChecks<RizzleReplicacheMutators<never>>(
+  `allows writing mutator implementations separately`,
+  async () => {
+    const schema = {
+      posts: r.keyValue(`p/[id]`, {
+        id: r.string(),
+        rank: r.number(`r`).indexed(`byRank`),
+      }),
+      createPost: r
+        .mutator({
+          id: r.string(),
+          rank: r.number(`r`),
+        })
+        .alias(`cp`),
+    };
+
+    const createPost: RizzleReplicacheMutators<
+      typeof schema
+    >[`createPost`] = async (db, options) => {
+      true satisfies IsEqual<typeof db.tx, WriteTransaction>;
+      true satisfies IsEqual<typeof options, { id: string; rank: number }>;
+
+      typeChecks(async () => {
+        const { id, rank } = options;
+        // native replicache tx API
+        await db.tx.set(`p/${id}`, { r: rank });
+
+        // rizzle convenience API
+        await db.posts.get({ id });
+        await db.posts.set({ id }, { rank });
+
+        // @ts-expect-error there's no rank2 in the schema
+        await db.posts.set({ id }, { rank2: 2 });
+      });
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    createPost;
+  },
+);
+
+typeChecks<RizzleReplicacheMutators<never>>(async () => {
+  const schema = {
+    posts: r.keyValue(`p/[id]`, { id: r.string() }),
+    createPost: r.mutator({ id: r.string() }),
+  };
+
+  // Only mutators are included
+  true satisfies IsEqual<
+    keyof RizzleReplicacheMutators<typeof schema>,
+    `createPost`
+  >;
+});
+
+typeChecks<RizzleReplicacheQuery<never>>(async () => {
+  const schema = {
+    posts: r.keyValue(`p/[id]`, { id: r.string() }),
+    createPost: r.mutator({ id: r.string() }),
+  };
+
+  // Only key-value are included
+  true satisfies IsEqual<keyof RizzleReplicacheQuery<typeof schema>, `posts`>;
+});
+
 void test(`replicache()`, async (t) => {
   const schema = {
     posts: r.keyValue(`p/[id]`, {
@@ -491,41 +745,7 @@ void test(`replicache()`, async (t) => {
         rank: r.number(`r`),
       })
       .alias(`cp`),
-    createPost2: r
-      .mutator({
-        id: r.string(),
-        rank: r.number(`r`),
-      })
-      .alias(`cp2`),
   };
-
-  const createPost2: RizzleReplicacheMutators<
-    typeof schema
-  >[`createPost2`] = async (db, { id, rank }) => {
-    true satisfies IsEqual<typeof db.tx, WriteTransaction>;
-    true satisfies IsEqual<typeof id, string>;
-    true satisfies IsEqual<typeof rank, number>;
-
-    typeChecks(async () => {
-      // native replicache tx API
-      await db.tx.set(`p/${id}`, { r: rank });
-
-      // rizzle convenience API
-      await db.posts.get({ id });
-      await db.posts.set({ id }, { rank });
-
-      // @ts-expect-error there's no rank2 in the schema
-      await db.posts.set({ id }, { rank2: 2 });
-    });
-  };
-
-  // Only mutators are included (i.e. not `posts`)
-  true satisfies IsEqual<
-    keyof RizzleReplicacheMutators<typeof schema>,
-    `createPost` | `createPost2`
-  >;
-  // Only key-value are included (i.e. not `createPost`)
-  true satisfies IsEqual<keyof RizzleReplicacheQuery<typeof schema>, `posts`>;
 
   let checkPointsReached = 0;
 
@@ -541,14 +761,11 @@ void test(`replicache()`, async (t) => {
         await db.posts.set({ id: options.id }, { rank: options.rank });
         checkPointsReached++;
       },
-      createPost2,
-      // @ts-expect-error there's no createPost3 in the schema
-      createPost3: createPost2,
     },
     (options) => {
       assert.deepEqual(
         mapValues(options.mutators, (v) => typeof v),
-        { cp: `function`, cp2: `function` },
+        { cp: `function` },
       );
       assert.deepEqual(options.indexes, {
         "posts.byRank": {
@@ -656,6 +873,33 @@ void test(`replicache()`, async (t) => {
   assert.equal(checkPointsReached, 4);
 });
 
+void test(`replicache() disallows unknown mutator implementations`, async () => {
+  const schema = {
+    posts: r.keyValue(`p/[id]`, { id: r.string() }),
+    createPost: r.mutator({ id: r.string() }),
+  };
+
+  // Only mutators are included (i.e. not `posts`)
+  true satisfies IsEqual<
+    keyof RizzleReplicacheMutators<typeof schema>,
+    `createPost`
+  >;
+  // Only key-value are included (i.e. not `createPost`)
+  true satisfies IsEqual<keyof RizzleReplicacheQuery<typeof schema>, `posts`>;
+
+  typeChecks(async () => {
+    r.replicache(testReplicacheOptions, schema, {
+      async createPost() {
+        // stub
+      },
+      // @ts-expect-error there's no createPost2 in the schema
+      async createPost2() {
+        // stub
+      },
+    });
+  });
+});
+
 void test(`replicache() mutator tx`, async () => {
   const schema = {
     counter: r.keyValue(`counter/[id]`, {
@@ -750,8 +994,62 @@ void test(`number()`, async (t) => {
   });
 });
 
-typeChecks(`RizzleIndexNames<>`, () => {
-  // Outer wrapping is RizzleIndexed.
+void test(`literal()`, async (t) => {
+  typeChecks(async () => {
+    r.literal(1, r.number());
+    r.literal(``, r.string());
+    // @ts-expect-error string isn't compatible with number
+    r.literal(`abc`, r.number());
+
+    using tx = makeMockTx(t);
+
+    {
+      const kv = r.keyValue(`foo`, { number: r.literal(1, r.number()) });
+
+      // .set()
+      await kv.set(tx, { id: `1` }, { number: 1 });
+      // @ts-expect-error 2 isn't literally 1
+      await kv.set(tx, { id: `1` }, { number: 2 });
+
+      // .get()
+      const v1 = await kv.get(tx, { id: `1` });
+      true satisfies IsEqual<typeof v1, { number: 1 } | undefined>;
+    }
+
+    {
+      const kv = r.keyValue(`foo`, { string: r.literal(`1`, r.string()) });
+
+      // .set()
+      await kv.set(tx, { id: `1` }, { string: `1` });
+      // @ts-expect-error '2' isn't literally '1'
+      await kv.set(tx, { id: `1` }, { string: `2` });
+
+      // .get()
+      const v1 = await kv.get(tx, { id: `1` });
+      true satisfies IsEqual<typeof v1, { string: `1` } | undefined>;
+    }
+  });
+
+  const posts = r.keyValue(`foo/[id]`, {
+    id: r.string(),
+    count: r.literal(5, r.number()).alias(`c`),
+  });
+
+  using tx = makeMockTx(t);
+
+  // Marshal and unmarshal round tripping
+  await posts.set(tx, { id: `1` }, { count: 5 });
+  const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
+  assert.deepEqual(marshaledData, { c: 5 });
+
+  tx.get.mock.mockImplementationOnce(async () => marshaledData);
+  assert.deepEqual(await posts.get(tx, { id: `1` }), {
+    count: 5,
+  });
+});
+
+typeChecks<RizzleIndexNames<never>>(() => {
+  // .string().indexed(…)
   true satisfies IsEqual<
     RizzleIndexNames<
       RizzleObject<{
@@ -763,17 +1061,28 @@ typeChecks(`RizzleIndexNames<>`, () => {
     `byDate` | `byName`
   >;
 
-  // Inner wrapping is RizzleIndexed.
+  // .string().indexed(…).alias()
   true satisfies IsEqual<
-    Prettify<
-      RizzleIndexNames<
-        RizzleObject<{
-          id: RizzlePrimitive<string, string>;
-          date: RizzleTypeAlias<
-            RizzleIndexed<RizzlePrimitive<Date, string>, `byDate`>
-          >;
-        }>
-      >
+    RizzleIndexNames<
+      RizzleObject<{
+        id: RizzlePrimitive<string, string>;
+        date: RizzleTypeAlias<
+          RizzleIndexed<RizzlePrimitive<Date, string>, `byDate`>
+        >;
+      }>
+    >,
+    `byDate`
+  >;
+
+  // .string().indexed(…).nullable()
+  true satisfies IsEqual<
+    RizzleIndexNames<
+      RizzleObject<{
+        id: RizzlePrimitive<string, string>;
+        date: RizzleNullable<
+          RizzleIndexed<RizzlePrimitive<Date, string>, `byDate`>
+        >;
+      }>
     >,
     `byDate`
   >;
@@ -796,10 +1105,27 @@ typeChecks<RizzleObjectInput<never>>(() => {
   >;
 });
 
+typeChecks<RizzleObjectMarshaled<never>>(() => {
+  type RawShape = {
+    id: RizzlePrimitive<string, number, string>;
+    date: RizzlePrimitive<Date, number, string>;
+  };
+
+  true satisfies IsEqual<
+    RizzleObjectMarshaled<RawShape>,
+    { id: number; date: number }
+  >;
+
+  true satisfies IsEqual<
+    RizzleObject<RawShape>[`_marshaled`],
+    { id: number; date: number }
+  >;
+});
+
 typeChecks<RizzleObjectOutput<never>>(() => {
   type RawShape = {
-    id: RizzlePrimitive<string, string>;
-    date: RizzlePrimitive<Date, string>;
+    id: RizzlePrimitive<string, number, string>;
+    date: RizzlePrimitive<Date, number, string>;
   };
 
   true satisfies IsEqual<
@@ -813,7 +1139,7 @@ typeChecks<RizzleObjectOutput<never>>(() => {
   >;
 });
 
-void test(keyPathVariableNames.name, () => {
+void test(`${keyPathVariableNames.name}()`, () => {
   assert.deepEqual(keyPathVariableNames(`foo/[id]`), [`id`]);
   assert.deepEqual(keyPathVariableNames(`foo/[id]/[bar]`), [`id`, `bar`]);
 });

--- a/projects/app/src/__tests__/data/rizzle.test.ts
+++ b/projects/app/src/__tests__/data/rizzle.test.ts
@@ -3,7 +3,6 @@ import {
   keyPathVariableNames,
   parseKeyPath,
   r,
-  rizzle,
   RizzleIndexed,
   RizzleIndexNames,
   RizzleObject,
@@ -530,7 +529,7 @@ void test(`replicache()`, async (t) => {
 
   let checkPointsReached = 0;
 
-  await using db = rizzle.replicache(
+  await using db = r.replicache(
     testReplicacheOptions,
     schema,
     {
@@ -670,7 +669,7 @@ void test(`replicache() mutator tx`, async () => {
       .alias(`ic`),
   };
 
-  await using db = rizzle.replicache(testReplicacheOptions, schema, {
+  await using db = r.replicache(testReplicacheOptions, schema, {
     async incrementCounter(db, options) {
       const { id } = options;
       const existingCount = await db.counter.get({ id });
@@ -705,7 +704,7 @@ void test(`replicache() index scan`, async () => {
       .alias(`at`),
   };
 
-  await using db = rizzle.replicache(testReplicacheOptions, schema, {
+  await using db = r.replicache(testReplicacheOptions, schema, {
     async appendText(db, options) {
       const { id } = options;
       const existing = await db.text.get({ id });

--- a/projects/app/src/app/learn/hsk1.tsx
+++ b/projects/app/src/app/learn/hsk1.tsx
@@ -2,7 +2,6 @@ import { QuizDeck } from "@/components/QuizDeck";
 import { useReplicache } from "@/components/ReplicacheContext";
 import { sentryCaptureException } from "@/components/util";
 import { generateQuestionForSkillOrThrow } from "@/data/generator";
-import { marshalSkillStateKey } from "@/data/marshal";
 import { HanziSkill, Question, QuestionType, SkillType } from "@/data/model";
 import { questionsForReview } from "@/data/query";
 import { allHsk1Words } from "@/dictionary/dictionary";
@@ -24,7 +23,7 @@ export default function LearnHsk1Page() {
       // Start with practicing skills that are due
       const questions: Question[] = (
         await r.replicache.query((tx) =>
-          questionsForReview(tx, {
+          questionsForReview(r, tx, {
             limit: quizSize,
             sampleSize: 50,
             filter: (skill) => hsk1Words.includes(skill.hanzi),
@@ -55,7 +54,7 @@ export default function LearnHsk1Page() {
                     isEqual(q.answer.b.skill, skill.hanzi)),
               ) &&
               // Don't include skills that are already practiced
-              !(await tx.has(marshalSkillStateKey(skill)))
+              !(await r.query.skillState.has(tx, { skill }))
             ) {
               try {
                 questions.push(await generateQuestionForSkillOrThrow(skill));

--- a/projects/app/src/app/learn/radicals.tsx
+++ b/projects/app/src/app/learn/radicals.tsx
@@ -22,7 +22,7 @@ export default function RadicalsPage() {
       const limit = 10;
       const questions: Question[] = (
         await r.replicache.query((tx) =>
-          questionsForReview(tx, {
+          questionsForReview(r, tx, {
             limit,
             sampleSize: 50,
             skillTypes: [

--- a/projects/app/src/app/learn/reviews.tsx
+++ b/projects/app/src/app/learn/reviews.tsx
@@ -1,6 +1,6 @@
 import { QuizDeck } from "@/components/QuizDeck";
 import { RectButton } from "@/components/RectButton";
-import { useQueryOnce } from "@/components/ReplicacheContext";
+import { useQueryOnce, useReplicache } from "@/components/ReplicacheContext";
 import { generateQuestionForSkillOrThrow } from "@/data/generator";
 import { IndexName, legacyIndexScanIter } from "@/data/marshal";
 import { questionsForReview } from "@/data/query";
@@ -11,8 +11,10 @@ import { router } from "expo-router";
 import { Text, View } from "react-native";
 
 export default function ReviewsPage() {
+  const r = useReplicache();
+
   const questions = useQueryOnce(async (tx) => {
-    const result = await questionsForReview(tx, {
+    const result = await questionsForReview(r, tx, {
       limit: 10,
       dueBeforeNow: true,
       // Look ahead at the next 50 skills, shuffle them and take 10. This way

--- a/projects/app/src/components/ReplicacheContext.tsx
+++ b/projects/app/src/components/ReplicacheContext.tsx
@@ -19,10 +19,9 @@ import {
 } from "replicache-react";
 import { kvStore } from "./replicacheOptions";
 
-const ReplicacheContext = createContext<RizzleReplicache<
-  typeof schema,
-  typeof mutators
-> | null>(null);
+export type Rizzle = RizzleReplicache<typeof schema, typeof mutators>;
+
+const ReplicacheContext = createContext<Rizzle | null>(null);
 
 export function ReplicacheProvider({ children }: React.PropsWithChildren) {
   const rizzle = useMemo(
@@ -65,7 +64,10 @@ export function ReplicacheProvider({ children }: React.PropsWithChildren) {
           async addSkillState(db, { skill, now }) {
             const exists = await db.skillState.has({ skill });
             if (!exists) {
-              await db.skillState.set({ skill }, { due: now });
+              await db.skillState.set(
+                { skill },
+                { due: now, created: now, srs: null },
+              );
             }
           },
         },

--- a/projects/app/src/components/ReplicacheContext.tsx
+++ b/projects/app/src/components/ReplicacheContext.tsx
@@ -1,6 +1,6 @@
 import { indexes } from "@/data/marshal";
 import { mutators } from "@/data/mutators";
-import { rizzle, RizzleReplicache } from "@/data/rizzle";
+import { r, RizzleReplicache } from "@/data/rizzle";
 import { schema } from "@/data/rizzleSchema";
 import { replicacheLicenseKey } from "@/env";
 import { invariant } from "@haohaohow/lib/invariant";
@@ -25,14 +25,40 @@ const ReplicacheContext = createContext<RizzleReplicache<
 > | null>(null);
 
 export function ReplicacheProvider({ children }: React.PropsWithChildren) {
-  const rep = useMemo(
+  const rizzle = useMemo(
     () =>
-      rizzle.replicache(
+      r.replicache(
         {
           name: `hao`,
           schemaVersion: `3`,
           licenseKey: replicacheLicenseKey,
           kvStore,
+          // pusher(requestBody, requestID) {
+          //   // eslint-disable-next-line no-console
+          //   console.log(`pusher(${JSON.stringify({ requestBody, requestID })})`);
+          //   throw new Error(`pushing not implemented`);
+          // },
+          // puller(req, requestID) {
+          //   invariant(req.pullVersion === 1);
+
+          //   // eslint-disable-next-line no-console
+          //   console.log(`puller: rep.clientID =`, rep.clientID);
+
+          //   // eslint-disable-next-line no-console
+          //   console.log(`puller: puller(…) requestId=${requestID} req=`, req);
+
+          //   return Promise.resolve({
+          //     response: {
+          //       cookie: req.cookie,
+          //       lastMutationIDChanges: { [rep.clientID]: 0 },
+          //       patch: [],
+          //     },
+          //     httpRequestInfo: {
+          //       errorMessage: ``,
+          //       httpStatusCode: 200,
+          //     },
+          //   } satisfies PullerResultV1);
+          // },
         },
         schema,
         {
@@ -51,42 +77,11 @@ export function ReplicacheProvider({ children }: React.PropsWithChildren) {
           });
         },
       ),
-    // new Replicache({
-
-    //   // pusher(requestBody, requestID) {
-    //   //   // eslint-disable-next-line no-console
-    //   //   console.log(`pusher(${JSON.stringify({ requestBody, requestID })})`);
-    //   //   throw new Error(`pushing not implemented`);
-    //   // },
-    //   // puller(req, requestID) {
-    //   //   invariant(req.pullVersion === 1);
-
-    //   //   // eslint-disable-next-line no-console
-    //   //   console.log(`puller: rep.clientID =`, rep.clientID);
-
-    //   //   // eslint-disable-next-line no-console
-    //   //   console.log(`puller: puller(…) requestId=${requestID} req=`, req);
-
-    //   //   return Promise.resolve({
-    //   //     response: {
-    //   //       cookie: req.cookie,
-    //   //       lastMutationIDChanges: { [rep.clientID]: 0 },
-    //   //       patch: [],
-    //   //     },
-    //   //     httpRequestInfo: {
-    //   //       errorMessage: ``,
-    //   //       httpStatusCode: 200,
-    //   //     },
-    //   //   } satisfies PullerResultV1);
-    //   // },
-    //   mutators,
-    //   indexes,
-    // }),
     [],
   );
 
   return (
-    <ReplicacheContext.Provider value={rep}>
+    <ReplicacheContext.Provider value={rizzle}>
       {children}
     </ReplicacheContext.Provider>
   );

--- a/projects/app/src/data/marshal.ts
+++ b/projects/app/src/data/marshal.ts
@@ -133,7 +133,7 @@ const MarshaledSkillStateValue = z.object({
   c: z.string().datetime(),
   /** srs */
   s: MarshaledSrsState,
-  /** difficulty */
+  /** due */
   d: z.string().datetime(),
 });
 export type MarshaledSkillStateValue = z.infer<typeof MarshaledSkillStateValue>;

--- a/projects/app/src/data/rizzle.ts
+++ b/projects/app/src/data/rizzle.ts
@@ -701,9 +701,6 @@ export const r = {
   keyValue,
   mutator,
   zod: RizzlePrimitive.create,
-};
-
-export const rizzle = {
   replicache,
 };
 

--- a/projects/app/src/data/rizzle.ts
+++ b/projects/app/src/data/rizzle.ts
@@ -23,16 +23,21 @@ interface RizzleTypeDef {
 }
 
 abstract class RizzleType<
-  Input = unknown,
   Def extends RizzleTypeDef = RizzleTypeDef,
-  Output = unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Input = any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Marshaled = any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Output = any,
 > {
-  readonly _output!: Output;
   readonly _input!: Input;
+  readonly _output!: Output;
+  readonly _marshaled!: Marshaled;
   readonly _def!: Def;
 
-  abstract getMarshal(): z.ZodType<Output, z.ZodTypeDef, Input>;
-  abstract getUnmarshal(): z.ZodType<Input, z.ZodTypeDef, Output>;
+  abstract getMarshal(): z.ZodType<Marshaled, z.ZodTypeDef, Input>;
+  abstract getUnmarshal(): z.ZodType<Output, z.ZodTypeDef, Marshaled>;
 
   _getIndexes(): IndexDefinitions {
     return {};
@@ -50,6 +55,10 @@ abstract class RizzleType<
     return RizzleTypeAlias.create(this, alias);
   }
 
+  nullable(): RizzleNullable<this> {
+    return RizzleNullable.create(this);
+  }
+
   indexed<IndexName extends string>(
     indexName: IndexName,
   ): RizzleIndexed<this, IndexName> {
@@ -57,16 +66,45 @@ abstract class RizzleType<
   }
 }
 
-interface RizzleTypeAliasDef<T extends RizzleType = RizzleType>
-  extends RizzleTypeDef {
+interface RizzleNullableDef<T extends RizzleType> extends RizzleTypeDef {
+  innerType: T;
+  typeName: `nullable`;
+}
+
+export class RizzleNullable<T extends RizzleType> extends RizzleType<
+  RizzleNullableDef<T>,
+  T[`_input`] | null,
+  T[`_marshaled`] | null,
+  T[`_output`] | null
+> {
+  getMarshal() {
+    return this._def.innerType.getMarshal().nullable();
+  }
+  getUnmarshal() {
+    return this._def.innerType.getUnmarshal().nullable();
+  }
+  _getIndexes() {
+    return this._def.innerType._getIndexes();
+  }
+  _getAlias(): string | undefined {
+    return this._def.innerType._getAlias();
+  }
+
+  static create = <T extends RizzleType>(type: T): RizzleNullable<T> => {
+    return new RizzleNullable({ innerType: type, typeName: `nullable` });
+  };
+}
+
+interface RizzleTypeAliasDef<T extends RizzleType> extends RizzleTypeDef {
   innerType: T;
   alias?: string | undefined;
   typeName: `alias`;
 }
 
 export class RizzleTypeAlias<T extends RizzleType> extends RizzleType<
-  T[`_input`],
   RizzleTypeAliasDef<T>,
+  T[`_input`],
+  T[`_marshaled`],
   T[`_output`]
 > {
   getMarshal() {
@@ -101,8 +139,9 @@ export class RizzleIndexed<
   T extends RizzleType,
   IndexName extends string,
 > extends RizzleType<
-  T[`_input`],
   RizzleIndexedDef<T, IndexName>,
+  T[`_input`],
+  T[`_marshaled`],
   T[`_output`]
 > {
   getMarshal() {
@@ -143,8 +182,9 @@ interface RizzleObjectDef<T extends RizzleRawObject = RizzleRawObject>
 }
 
 export class RizzleObject<T extends RizzleRawObject> extends RizzleType<
-  RizzleObjectInput<T>,
   RizzleObjectDef<T>,
+  RizzleObjectInput<T>,
+  RizzleObjectMarshaled<T>,
   RizzleObjectOutput<T>
 > {
   #keyToAlias: Record<string, string>;
@@ -162,7 +202,11 @@ export class RizzleObject<T extends RizzleRawObject> extends RizzleType<
       .object(mapValues(this._def.shape, (v) => v.getMarshal()))
       .transform((x) =>
         mapKeys(x, (_v, k) => this.#keyToAlias[k]),
-      ) as unknown as z.ZodType<this[`_output`], z.ZodAnyDef, this[`_input`]>;
+      ) as unknown as z.ZodType<
+      this[`_marshaled`],
+      z.ZodAnyDef,
+      this[`_input`]
+    >;
   }
 
   getUnmarshal() {
@@ -175,7 +219,11 @@ export class RizzleObject<T extends RizzleRawObject> extends RizzleType<
       )
       .transform((x) =>
         mapKeys(x, (_v, k) => this.#aliasToKey[k]),
-      ) as unknown as z.ZodType<this[`_input`], z.ZodAnyDef, this[`_output`]>;
+      ) as unknown as z.ZodType<
+      this[`_output`],
+      z.ZodAnyDef,
+      this[`_marshaled`]
+    >;
   }
 
   _getIndexes() {
@@ -196,18 +244,19 @@ export class RizzleObject<T extends RizzleRawObject> extends RizzleType<
   };
 }
 
-interface RizzlePrimitiveDef<I, O> extends RizzleTypeDef {
-  marshal: z.ZodType<O, z.ZodTypeDef, I>;
-  unmarshal: z.ZodType<I, z.ZodTypeDef, O>;
+interface RizzlePrimitiveDef<I, M, O> extends RizzleTypeDef {
+  marshal: z.ZodType<M, z.ZodTypeDef, I>;
+  unmarshal: z.ZodType<O, z.ZodTypeDef, M>;
   typeName: `primitive`;
 }
 
 /**
  * A simple type that can be marshaled and unmarshaled.
  */
-export class RizzlePrimitive<I, O> extends RizzleType<
+export class RizzlePrimitive<I, M, O = I> extends RizzleType<
+  RizzlePrimitiveDef<I, M, O>,
   I,
-  RizzlePrimitiveDef<I, O>,
+  M,
   O
 > {
   getMarshal() {
@@ -226,10 +275,10 @@ export class RizzlePrimitive<I, O> extends RizzleType<
     return;
   }
 
-  static create = <I, O>(
-    marshal: z.ZodType<O, z.ZodTypeDef, I>,
-    unmarshal: z.ZodType<I, z.ZodTypeDef, O>,
-  ): RizzlePrimitive<I, O> => {
+  static create = <I, M, O>(
+    marshal: z.ZodType<M, z.ZodTypeDef, I>,
+    unmarshal: z.ZodType<O, z.ZodTypeDef, M>,
+  ): RizzlePrimitive<I, M, O> => {
     return new RizzlePrimitive({ marshal, unmarshal, typeName: `primitive` });
   };
 }
@@ -244,33 +293,28 @@ abstract class RizzleRoot<Def extends RizzleTypeDef = RizzleTypeDef> {
 
 type RizzleRawSchemaForKeyPath<KeyPath extends string> = Record<
   ExtractVariableNames<KeyPath>,
-  RizzleType
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  RizzleType<RizzleTypeDef, any, string>
 >;
 
 type KVKeyType<
   S extends RizzleRawObject,
   KeyPath extends string,
 > = RizzleObject<Pick<S, ExtractVariableNames<KeyPath>>>;
-type KVKeyInput<S extends RizzleRawObject, KeyPath extends string> = KVKeyType<
-  S,
-  KeyPath
->[`_input`];
 type KVValueType<
   S extends RizzleRawObject,
   KeyPath extends string,
 > = RizzleObject<Omit<S, ExtractVariableNames<KeyPath>>>;
-type KVValueInput<
-  S extends RizzleRawObject,
-  KeyPath extends string,
-> = KVValueType<S, KeyPath>[`_input`];
 
 interface RizzleKVDef<KeyPath extends string, S extends RizzleRawObject>
   extends RizzleTypeDef {
   keyPath: KeyPath;
   keyType: KVKeyType<S, KeyPath>;
   valueType: KVValueType<S, KeyPath>;
-  interpolateKey: (key: KVKeyInput<S, KeyPath>) => string;
-  uninterpolateKey: (key: string) => KVKeyInput<S, KeyPath> | undefined;
+  interpolateKey: (key: KVKeyType<S, KeyPath>[`_input`]) => string;
+  uninterpolateKey: (
+    key: string,
+  ) => KVKeyType<S, KeyPath>[`_output`] | undefined;
   typeName: `keyValue`;
 }
 
@@ -280,15 +324,15 @@ export class RizzleKV<
 > extends RizzleRoot<RizzleKVDef<KeyPath, S>> {
   async has(
     tx: ReadTransaction,
-    key: KVKeyInput<S, KeyPath>,
+    key: KVKeyType<S, KeyPath>[`_input`],
   ): Promise<boolean> {
     return await tx.has(this._def.interpolateKey(key));
   }
 
   async get(
     tx: ReadTransaction,
-    key: KVKeyInput<S, KeyPath>,
-  ): Promise<KVValueInput<S, KeyPath> | undefined> {
+    key: KVKeyType<S, KeyPath>[`_input`],
+  ): Promise<KVValueType<S, KeyPath>[`_output`] | undefined> {
     const valueData = await tx.get(this._def.interpolateKey(key));
     if (valueData === undefined) {
       return valueData;
@@ -298,8 +342,8 @@ export class RizzleKV<
 
   async set(
     tx: WriteTransaction,
-    key: KVKeyInput<S, KeyPath>,
-    value: KVValueInput<S, KeyPath>,
+    key: KVKeyType<S, KeyPath>[`_input`],
+    value: KVValueType<S, KeyPath>[`_input`],
   ) {
     await tx.set(
       this._def.interpolateKey(key),
@@ -308,10 +352,16 @@ export class RizzleKV<
   }
 
   getIndexes() {
-    return mapValues(this._def.valueType._getIndexes(), (v) => ({
-      ...v,
-      prefix: this._def.keyPath.slice(0, this._def.keyPath.indexOf(`[`)),
-    })) as Record<RizzleIndexNames<KVValueType<S, KeyPath>>, IndexDefinition>;
+    return mapValues(this._def.valueType._getIndexes(), (v) => {
+      const firstVarIndex = this._def.keyPath.indexOf(`[`);
+      return {
+        ...v,
+        prefix:
+          firstVarIndex > 0
+            ? this._def.keyPath.slice(0, firstVarIndex)
+            : this._def.keyPath,
+      };
+    }) as Record<RizzleIndexNames<KVValueType<S, KeyPath>>, IndexDefinition>;
   }
 
   static create = <
@@ -382,8 +432,12 @@ export type RizzleObjectInput<T extends RizzleRawObject> = {
   [K in keyof T]: T[K][`_input`];
 };
 
-export type RizzleObjectOutput<T extends RizzleRawObject> = {
+export type RizzleObjectMarshaled<T extends RizzleRawObject> = {
   // TODO: this is missing key aliases
+  [K in keyof T]: T[K][`_marshaled`];
+};
+
+export type RizzleObjectOutput<T extends RizzleRawObject> = {
   [K in keyof T]: T[K][`_output`];
 };
 
@@ -393,11 +447,13 @@ export type RizzleIndexNames<T extends RizzleType> =
     ? IndexName
     : T extends RizzleTypeAlias<infer Wrapped>
       ? RizzleIndexNames<Wrapped>
-      : T extends RizzleObject<infer Shape>
-        ? {
-            [K in keyof Shape]: RizzleIndexNames<Shape[K]>;
-          }[keyof Shape]
-        : never;
+      : T extends RizzleNullable<infer Wrapped>
+        ? RizzleIndexNames<Wrapped>
+        : T extends RizzleObject<infer Shape>
+          ? {
+              [K in keyof Shape]: RizzleIndexNames<Shape[K]>;
+            }[keyof Shape]
+          : never;
 
 type WithoutFirstArgument<T> = T extends (
   arg1: never,
@@ -446,8 +502,8 @@ export type RizzleReplicacheQuery<S extends RizzleRawSchema> = {
           tx: ReadTransaction,
         ) => AsyncGenerator<
           [
-            S[K][`_def`][`keyType`][`_input`],
-            S[K][`_def`][`valueType`][`_input`],
+            S[K][`_def`][`keyType`][`_output`],
+            S[K][`_def`][`valueType`][`_output`],
           ]
         >
       > &
@@ -465,6 +521,13 @@ const number = (alias?: string) => {
   return alias != null ? result.alias(alias) : result;
 };
 
+/**
+ * A UNIX timestamp number.
+ *
+ * Be careful using this for storage (`r.keyValue`) because it can't be indexed
+ * and if it's used in a key path it isn't a stable length so it's not
+ * guaranteed to sort correctly. For storage use {@link datetime} instead.
+ */
 const timestamp = memoize(() =>
   RizzlePrimitive.create(
     z.union([z.number(), z.date().transform((x) => x.getTime())]),
@@ -479,13 +542,26 @@ const timestamp = memoize(() =>
   ),
 );
 
-const enum_ = <
-  T extends Record<string, string | number>,
-  U extends string = string,
->(
+/**
+ * Stores as ISO-8601 so that it can be indexed and sorted reliably. (numbers
+ * can't be indexed in replicache).
+ */
+const datetime = memoize(() =>
+  RizzlePrimitive.create(
+    z.date().transform((x) => x.toISOString()),
+    z
+      .string()
+      .refine((x) => x.endsWith(`Z`))
+      .transform((x) => new Date(x)), // ISO8601
+  ),
+);
+
+type EnumType = Record<string, string | number>;
+
+const enum_ = <T extends EnumType, U extends string = string>(
   e: T,
   mapping: Record<T[keyof T], U>,
-): RizzlePrimitive<T[keyof T], string> => {
+): RizzlePrimitive<T[keyof T], string, T[keyof T]> => {
   const marshalMap = new Map<T[keyof T], U>(
     Object.entries(mapping).map(([kStr, v]) => {
       const k = Object.entries(e).find(
@@ -518,6 +594,18 @@ const enum_ = <
     }),
   );
 };
+
+const literal = <T extends RizzleType, const V extends T[`_input`]>(
+  value: V,
+  type: T,
+) =>
+  RizzlePrimitive.create(
+    z.literal(value).pipe(type.getMarshal()),
+    type
+      .getUnmarshal()
+      .pipe(z.literal(value))
+      .refine((x): x is V => x === value),
+  );
 
 const object = <S extends RizzleRawObject>(shape: S) => {
   return RizzleObject.create(shape);
@@ -696,12 +784,14 @@ export const r = {
   string,
   number,
   timestamp,
+  datetime,
   enum: enum_,
   object,
   keyValue,
   mutator,
-  zod: RizzlePrimitive.create,
+  primitive: RizzlePrimitive.create,
   replicache,
+  literal,
 };
 
 export function invalid(ctx: z.RefinementCtx, message: string): typeof z.NEVER {

--- a/projects/app/src/data/rizzleSchema.ts
+++ b/projects/app/src/data/rizzleSchema.ts
@@ -119,22 +119,38 @@ const rSrsType = memoize(() =>
     [SrsType.FsrsFourPointFive]: `1`,
   }),
 );
-// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-rSrsType;
+
+const rSrsState = memoize(
+  () =>
+    // r.discriminatedUnion(`type`, [
+    //   r.object({
+    //     type: r.literal(SrsType.Null),
+    //   }),
+    r.object({
+      type: r.literal(SrsType.FsrsFourPointFive, rSrsType()),
+      stability: r.number(),
+      difficulty: r.number(),
+    }),
+  // ]),
+);
 
 // export const counter = keyValue(`counter`, {
 // TODO: doesn't support non-object keys.
 // });
 
-export const skillReview = r.keyValue(`sr/[skill]/[timestamp]`, {
+export const skillReview = r.keyValue(`sr/[skill]/[when]`, {
   skill: rSkillId(),
-  timestamp: r.timestamp(),
+  when: r.datetime(),
 
   rating: rFsrsRating.alias(`r`),
 });
 
 export const skillState = r.keyValue(`s/[skill]`, {
   skill: rSkillId(),
+
+  created: r.timestamp().alias(`c`),
+  srs: rSrsState().nullable().alias(`s`),
+  due: r.timestamp().alias(`d`).indexed(`byDue`),
 });
 
 export const addSkillState = r.mutator({


### PR DESCRIPTION
This pull request includes several changes aimed at improving the handling and querying of skill states and questions for review in the learning application. The changes involve updates to the Replicache context, query functions, and data types.

### Replicache Context and Query Updates:
* Updated the `ReplicacheContext` to use `RizzleReplicache` with a new alias `Rizzle` and modified the provider to use `r.replicache` instead of `rizzle.replicache`. [[1]](diffhunk://#diff-071215ee77f71b2e672dba7671c458a333683377476bc280350e9b653882d7d9L3-R3) [[2]](diffhunk://#diff-071215ee77f71b2e672dba7671c458a333683377476bc280350e9b653882d7d9L22-R70) [[3]](diffhunk://#diff-071215ee77f71b2e672dba7671c458a333683377476bc280350e9b653882d7d9L54-R86)
* Modified the `questionsForReview` function to accept `Rizzle` as a parameter and updated its usage across various files. [[1]](diffhunk://#diff-74b117a4b513d2fd9ccf4ca5a7b9927d8b3ef283646b51886f1e72d76f487cf5L27-R26) [[2]](diffhunk://#diff-b48c7dea916c226a509a69b74d436463961072433802e38bcec2cbc6dd4e1255L25-R25) [[3]](diffhunk://#diff-ff5e69508ccc12df375020933ce3e8ce243e2a00b51b64fd807d97029673955eR14-R17) [[4]](diffhunk://#diff-921a7db1fd89e7ec8cefdd9a9bf4d291a4f34d192a195336e1d1c13dda7f15ccR1-R10) [[5]](diffhunk://#diff-921a7db1fd89e7ec8cefdd9a9bf4d291a4f34d192a195336e1d1c13dda7f15ccL23-R24)

### Skill State Handling:
* Changed the way skill states are checked and set by replacing `marshalSkillStateKey` with `r.query.skillState` and updating the skill state structure to include additional fields like `created` and `srs`. [[1]](diffhunk://#diff-74b117a4b513d2fd9ccf4ca5a7b9927d8b3ef283646b51886f1e72d76f487cf5L58-R57) [[2]](diffhunk://#diff-071215ee77f71b2e672dba7671c458a333683377476bc280350e9b653882d7d9L54-R86)

### Data Type Enhancements:
* Enhanced the `RizzleType` class to include new type parameters for marshaled data and added methods for nullable types. [[1]](diffhunk://#diff-e96d082acf2a248f148cda8fdba6c39f62bbf8f116d5fe1025027d35d56fee25L26-R40) [[2]](diffhunk://#diff-e96d082acf2a248f148cda8fdba6c39f62bbf8f116d5fe1025027d35d56fee25R58-R107) [[3]](diffhunk://#diff-e96d082acf2a248f148cda8fdba6c39f62bbf8f116d5fe1025027d35d56fee25L104-R144) [[4]](diffhunk://#diff-e96d082acf2a248f148cda8fdba6c39f62bbf8f116d5fe1025027d35d56fee25L146-R187) [[5]](diffhunk://#diff-e96d082acf2a248f148cda8fdba6c39f62bbf8f116d5fe1025027d35d56fee25L165-R209) [[6]](diffhunk://#diff-e96d082acf2a248f148cda8fdba6c39f62bbf8f116d5fe1025027d35d56fee25L178-R226) [[7]](diffhunk://#diff-e96d082acf2a248f148cda8fdba6c39f62bbf8f116d5fe1025027d35d56fee25L199-R259)
* Updated the `RizzleKV` class to handle marshaled types and improved the key interpolation logic. [[1]](diffhunk://#diff-e96d082acf2a248f148cda8fdba6c39f62bbf8f116d5fe1025027d35d56fee25L283-R335) [[2]](diffhunk://#diff-e96d082acf2a248f148cda8fdba6c39f62bbf8f116d5fe1025027d35d56fee25L301-R346) [[3]](diffhunk://#diff-e96d082acf2a248f148cda8fdba6c39f62bbf8f116d5fe1025027d35d56fee25L311-R364)

### Miscellaneous:
* Removed unused imports and refactored import statements for better clarity and consistency. [[1]](diffhunk://#diff-74b117a4b513d2fd9ccf4ca5a7b9927d8b3ef283646b51886f1e72d76f487cf5L5) [[2]](diffhunk://#diff-ff5e69508ccc12df375020933ce3e8ce243e2a00b51b64fd807d97029673955eL3-R3)
* Updated comments and documentation to reflect changes in the skill state and query handling.

These changes collectively improve the robustness and maintainability of the codebase, particularly in handling skill states and querying data for reviews.