### PR TITLE
Allow choosing pinyin initial/final

### DIFF
--- a/projects/app/drizzle/0008_fancy_pet_avengers.sql
+++ b/projects/app/drizzle/0008_fancy_pet_avengers.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "haohaohow"."pinyinFinalAssociation" (
+	"id" text PRIMARY KEY NOT NULL,
+	"userId" text NOT NULL,
+	"final" text NOT NULL,
+	"name" text NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "pinyinFinalAssociation_userId_final_unique" UNIQUE("userId","final")
+);
+--> statement-breakpoint
+CREATE TABLE "haohaohow"."pinyinInitialAssociation" (
+	"id" text PRIMARY KEY NOT NULL,
+	"userId" text NOT NULL,
+	"initial" text NOT NULL,
+	"name" text NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "pinyinInitialAssociation_userId_initial_unique" UNIQUE("userId","initial")
+);
+--> statement-breakpoint
+ALTER TABLE "haohaohow"."pinyinFinalAssociation" ADD CONSTRAINT "pinyinFinalAssociation_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "haohaohow"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "haohaohow"."pinyinInitialAssociation" ADD CONSTRAINT "pinyinInitialAssociation_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "haohaohow"."user"("id") ON DELETE no action ON UPDATE no action;

--- a/projects/app/drizzle/meta/0008_snapshot.json
+++ b/projects/app/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,648 @@
+{
+  "id": "7267e242-58f5-492b-aa8b-12dbb88469e0",
+  "prevId": "ef61a59f-3548-4761-86ba-de2d4f99957a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "haohaohow.authOAuth2": {
+      "name": "authOAuth2",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerUserId": {
+          "name": "providerUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authOAuth2_userId_user_id_fk": {
+          "name": "authOAuth2_userId_user_id_fk",
+          "tableFrom": "authOAuth2",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authOAuth2_provider_providerUserId_unique": {
+          "name": "authOAuth2_provider_providerUserId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "providerUserId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.authSession": {
+      "name": "authSession",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authSession_userId_user_id_fk": {
+          "name": "authSession_userId_user_id_fk",
+          "tableFrom": "authSession",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.pinyinFinalAssociation": {
+      "name": "pinyinFinalAssociation",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final": {
+          "name": "final",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pinyinFinalAssociation_userId_user_id_fk": {
+          "name": "pinyinFinalAssociation_userId_user_id_fk",
+          "tableFrom": "pinyinFinalAssociation",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pinyinFinalAssociation_userId_final_unique": {
+          "name": "pinyinFinalAssociation_userId_final_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "final"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.pinyinInitialAssociation": {
+      "name": "pinyinInitialAssociation",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial": {
+          "name": "initial",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pinyinInitialAssociation_userId_user_id_fk": {
+          "name": "pinyinInitialAssociation_userId_user_id_fk",
+          "tableFrom": "pinyinInitialAssociation",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pinyinInitialAssociation_userId_initial_unique": {
+          "name": "pinyinInitialAssociation_userId_initial_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "initial"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.replicacheClient": {
+      "name": "replicacheClient",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientGroupId": {
+          "name": "clientGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMutationId": {
+          "name": "lastMutationId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "replicacheClient_clientGroupId_replicacheClientGroup_id_fk": {
+          "name": "replicacheClient_clientGroupId_replicacheClientGroup_id_fk",
+          "tableFrom": "replicacheClient",
+          "tableTo": "replicacheClientGroup",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "clientGroupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.replicacheClientGroup": {
+      "name": "replicacheClientGroup",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cvrVersion": {
+          "name": "cvrVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "replicacheClientGroup_userId_user_id_fk": {
+          "name": "replicacheClientGroup_userId_user_id_fk",
+          "tableFrom": "replicacheClientGroup",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.replicacheCvr": {
+      "name": "replicacheCvr",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastMutationIds": {
+          "name": "lastMutationIds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entities": {
+          "name": "entities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.replicacheMutation": {
+      "name": "replicacheMutation",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutation": {
+          "name": "mutation",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "replicacheMutation_clientId_replicacheClient_id_fk": {
+          "name": "replicacheMutation_clientId_replicacheClient_id_fk",
+          "tableFrom": "replicacheMutation",
+          "tableTo": "replicacheClient",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.skillRating": {
+      "name": "skillRating",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skillId": {
+          "name": "skillId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skillRating_userId_user_id_fk": {
+          "name": "skillRating_userId_user_id_fk",
+          "tableFrom": "skillRating",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.skillState": {
+      "name": "skillState",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skillId": {
+          "name": "skillId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "srs": {
+          "name": "srs",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dueAt": {
+          "name": "dueAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skillState_userId_user_id_fk": {
+          "name": "skillState_userId_user_id_fk",
+          "tableFrom": "skillState",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skillState_userId_skillId_unique": {
+          "name": "skillState_userId_skillId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "skillId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.user": {
+      "name": "user",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "haohaohow": "haohaohow"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/projects/app/drizzle/meta/_journal.json
+++ b/projects/app/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1735978130893,
       "tag": "0007_productive_sphinx",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1736061761676,
+      "tag": "0008_fancy_pet_avengers",
+      "breakpoints": true
     }
   ]
 }

--- a/projects/app/src/app/(sidenav)/history.tsx
+++ b/projects/app/src/app/(sidenav)/history.tsx
@@ -1,7 +1,4 @@
-import {
-  useReplicache,
-  useReplicacheSubscribe,
-} from "@/components/ReplicacheContext";
+import { useRizzleQuery } from "@/components/ReplicacheContext";
 import { Rating } from "@/util/fsrs";
 import reverse from "lodash/reverse";
 import sortBy from "lodash/sortBy";
@@ -9,23 +6,27 @@ import { ScrollView, Text, View } from "react-native";
 
 export default function HistoryPage() {
   const start = Date.now();
-  const db = useReplicache();
 
-  const data = useReplicacheSubscribe(async (tx) => {
-    const result = [];
-    for await (const [key, value] of db.query.skillState.byDue(tx)) {
-      result.push([key, value] as const);
-      if (result.length >= 50) {
-        break;
+  const dataQuery = useRizzleQuery(
+    [`HistoryPage`, `skillState`],
+    async (r, tx) => {
+      const result = [];
+      for await (const [key, value] of r.query.skillState.byDue(tx)) {
+        result.push([key, value] as const);
+        if (result.length >= 50) {
+          break;
+        }
       }
-    }
-    return result;
-  });
+      return result;
+    },
+  );
 
-  const skillReviews = useReplicacheSubscribe(async (tx) =>
-    Array.fromAsync(db.query.skillRating.scan(tx)).then((reviews) =>
-      reverse(sortBy(reviews, (x) => x[0].when.getTime())),
-    ),
+  const skillRatingsQuery = useRizzleQuery(
+    [`HistoryPage`, `skillRatings`],
+    async (r, tx) =>
+      Array.fromAsync(r.query.skillRating.scan(tx)).then((reviews) =>
+        reverse(sortBy(reviews, (x) => x[0].when.getTime())),
+      ),
   );
 
   const renderTime = Date.now() - start;
@@ -44,7 +45,7 @@ export default function HistoryPage() {
         <View className="flex-1 items-center gap-[10px]">
           <Text className="text-xl text-text">upcoming</Text>
 
-          {data?.map(([key, value], i) => (
+          {dataQuery.data?.map(([key, value], i) => (
             <View key={i}>
               <Text className="text-text">
                 {key.skill.hanzi}: {value.due.toISOString()}
@@ -56,7 +57,7 @@ export default function HistoryPage() {
         <View>
           <Text className="self-center text-xl text-text">history</Text>
 
-          {skillReviews?.map(([key, value], i) => (
+          {skillRatingsQuery.data?.map(([key, value], i) => (
             <View key={i}>
               <Text className="text-text">
                 {value.rating === Rating.Again

--- a/projects/app/src/app/(sidenav)/history.tsx
+++ b/projects/app/src/app/(sidenav)/history.tsx
@@ -23,7 +23,7 @@ export default function HistoryPage() {
   });
 
   const skillReviews = useReplicacheSubscribe(async (tx) =>
-    Array.fromAsync(db.query.skillReview.scan(tx)).then((reviews) =>
+    Array.fromAsync(db.query.skillRating.scan(tx)).then((reviews) =>
       reverse(sortBy(reviews, (x) => x[0].when.getTime())),
     ),
   );

--- a/projects/app/src/components/ReplicacheContext.tsx
+++ b/projects/app/src/components/ReplicacheContext.tsx
@@ -105,10 +105,10 @@ export function ReplicacheProvider({ children }: React.PropsWithChildren) {
         },
         async reviewSkill(tx, { skill, rating, now }) {
           // Save a record of the review.
-          await tx.skillReview.set({ skill, when: now }, { rating });
+          await tx.skillRating.set({ skill, when: now }, { rating });
 
           let state: UpcomingReview | null = null;
-          for await (const [{ when }, { rating }] of tx.skillReview.scan({
+          for await (const [{ when }, { rating }] of tx.skillRating.scan({
             skill,
           })) {
             state = nextReview(state, rating, when);

--- a/projects/app/src/components/ReplicacheContext.tsx
+++ b/projects/app/src/components/ReplicacheContext.tsx
@@ -6,6 +6,7 @@ import { AppRouter } from "@/server/routers/_app";
 import { nextReview, UpcomingReview } from "@/util/fsrs";
 import { trpc } from "@/util/trpc";
 import { invariant } from "@haohaohow/lib/invariant";
+import { QueryKey, useQuery, useQueryClient } from "@tanstack/react-query";
 import { TRPCClientError } from "@trpc/client";
 import {
   createContext,
@@ -16,10 +17,6 @@ import {
   useState,
 } from "react";
 import { HTTPRequestInfo, PullResponseV1, ReadTransaction } from "replicache";
-import {
-  useSubscribe as replicacheReactUseSubscribe,
-  UseSubscribeOptions,
-} from "replicache-react";
 import { useAuth } from "./auth";
 import { kvStore } from "./replicacheOptions";
 import { sentryCaptureException } from "./util";
@@ -129,6 +126,12 @@ export function ReplicacheProvider({ children }: React.PropsWithChildren) {
             },
           );
         },
+        async setPinyinInitialAssociation(tx, { initial, name }) {
+          await tx.pinyinInitialAssociation.set({ initial }, { name });
+        },
+        async setPinyinFinalAssociation(tx, { final, name }) {
+          await tx.pinyinFinalAssociation.set({ final }, { name });
+        },
       },
     );
   }, [auth.isAuthenticated, pushMutate, pullMutate]);
@@ -146,18 +149,42 @@ export function useReplicache() {
   return r;
 }
 
-export function useReplicacheSubscribe<QueryRet, Default = undefined>(
-  query: (tx: ReadTransaction) => Promise<QueryRet>,
-  options?: UseSubscribeOptions<QueryRet, Default>,
+export function useRizzleQuery<QueryRet>(
+  key: QueryKey,
+  query: (r: Rizzle, tx: ReadTransaction) => Promise<QueryRet>,
 ) {
+  const queryClient = useQueryClient();
   const r = useReplicache();
-  // The types of replicache-react seem wonky and don't support passing in a
-  // replicache instance.
-  return replicacheReactUseSubscribe<ReadTransaction, QueryRet, Default>(
-    r.replicache,
-    query,
-    options,
-  );
+
+  // The reference for `query` usually changes on every render because the
+  // function is written inline and the reference changes.
+  //
+  // eslint-disable-next-line react-compiler/react-compiler
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const stableQuery = useMemo(() => query, [key]);
+
+  useEffect(() => {
+    const unsubscribe = r.replicache.subscribe((tx) => stableQuery(r, tx), {
+      onData: (data) => {
+        queryClient.setQueryData(key, data);
+      },
+      onError: (e) => {
+        sentryCaptureException(e);
+      },
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [key, stableQuery, queryClient, r]);
+
+  const result = useQuery({
+    queryKey: key,
+    queryFn: () => r.replicache.query((tx) => query(r, tx)),
+    throwOnError: true,
+  });
+
+  return result;
 }
 
 type Result<QueryRet> =

--- a/projects/app/src/data/model.ts
+++ b/projects/app/src/data/model.ts
@@ -26,7 +26,7 @@ export interface SkillState {
   due: Date;
 }
 
-export interface SkillReview {
+export interface SkillRating {
   rating: Rating;
 }
 

--- a/projects/app/src/data/rizzleSchema.ts
+++ b/projects/app/src/data/rizzleSchema.ts
@@ -167,7 +167,7 @@ export const reviewSkill = r.mutator({
 });
 
 export const schema = {
-  skillReview: skillRating,
+  skillRating,
   skillState,
   addSkillState,
   reviewSkill,

--- a/projects/app/src/data/rizzleSchema.ts
+++ b/projects/app/src/data/rizzleSchema.ts
@@ -136,9 +136,9 @@ const rSrsState = memoize(
   // ]),
 );
 
-// export const counter = keyValue(`counter`, {
-// TODO: doesn't support non-object keys.
-// });
+//
+// Skills
+//
 
 export const skillRating = r.entity(`sr/[skill]/[when]`, {
   skill: rSkillId(),
@@ -166,14 +166,41 @@ export const reviewSkill = r.mutator({
   now: r.timestamp().alias(`n`),
 });
 
+//
+// Pinyin mnemonics
+//
+
+export const pinyinInitialAssociation = r.entity(`pi/[initial]`, {
+  initial: r.string(),
+  name: r.string().alias(`n`),
+});
+
+export const pinyinFinalAssociation = r.entity(`pf/[final]`, {
+  final: r.string(),
+  name: r.string().alias(`n`),
+});
+
+export const setPinyinInitialAssociation = r.mutator({
+  initial: r.string().alias(`i`),
+  name: r.string().alias(`n`),
+  now: r.timestamp().alias(`t`),
+});
+
+export const setPinyinFinalAssociation = r.mutator({
+  final: r.string().alias(`f`),
+  name: r.string().alias(`n`),
+  now: r.timestamp().alias(`t`),
+});
+
+// --
+
 export const schema = {
+  addSkillState,
+  pinyinFinalAssociation,
+  pinyinInitialAssociation,
+  setPinyinInitialAssociation,
+  setPinyinFinalAssociation,
+  reviewSkill,
   skillRating,
   skillState,
-  addSkillState,
-  reviewSkill,
 };
-
-// export const pinyinInitialAssociation = rizzle.keyValue(`pi/[initial]`, {
-//   initial: rizzle.string(),
-//   name: rizzle.string().alias(`n`),
-// });

--- a/projects/app/src/server/schema.ts
+++ b/projects/app/src/server/schema.ts
@@ -1,4 +1,4 @@
-import * as p from "drizzle-orm/pg-core";
+import * as s from "drizzle-orm/pg-core";
 import { customAlphabet } from "nanoid";
 
 const alphabet = `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz`;
@@ -6,11 +6,11 @@ const length = 12;
 
 const nanoid = customAlphabet(alphabet, length);
 
-export const schema = p.pgSchema(`haohaohow`);
+export const schema = s.pgSchema(`haohaohow`);
 
 export const user = schema.table(`user`, {
-  id: p.text(`id`).primaryKey().$defaultFn(nanoid),
-  createdAt: p
+  id: s.text(`id`).primaryKey().$defaultFn(nanoid),
+  createdAt: s
     .timestamp(`createdAt`, {
       mode: `date`,
       withTimezone: true,
@@ -20,12 +20,12 @@ export const user = schema.table(`user`, {
 });
 
 export const authSession = schema.table(`authSession`, {
-  id: p.text(`id`).primaryKey(),
-  userId: p
+  id: s.text(`id`).primaryKey(),
+  userId: s
     .text(`userId`)
     .notNull()
     .references(() => user.id),
-  expiresAt: p
+  expiresAt: s
     .timestamp(`expiresAt`, {
       mode: `date`,
       withTimezone: true,
@@ -36,51 +36,83 @@ export const authSession = schema.table(`authSession`, {
 export const authOAuth2 = schema.table(
   `authOAuth2`,
   {
-    id: p.text(`id`).primaryKey().$defaultFn(nanoid),
-    userId: p
+    id: s.text(`id`).primaryKey().$defaultFn(nanoid),
+    userId: s
       .text(`userId`)
       .references(() => user.id)
       .notNull(),
-    provider: p.text(`provider`).notNull(),
+    provider: s.text(`provider`).notNull(),
     /**
      * The ID that the provider uses to identify the user.
      */
-    providerUserId: p.text(`providerUserId`).notNull(),
-    createdAt: p.timestamp(`timestamp`).defaultNow().notNull(),
+    providerUserId: s.text(`providerUserId`).notNull(),
+    createdAt: s.timestamp(`timestamp`).defaultNow().notNull(),
   },
-  (t) => [p.unique().on(t.provider, t.providerUserId)],
+  (t) => [s.unique().on(t.provider, t.providerUserId)],
 );
 
 export const skillRating = schema.table(`skillRating`, {
-  id: p.text(`id`).primaryKey().$defaultFn(nanoid),
-  userId: p
+  id: s.text(`id`).primaryKey().$defaultFn(nanoid),
+  userId: s
     .text(`userId`)
     .references(() => user.id)
     .notNull(),
-  skillId: p.text(`skillId`).notNull(),
-  rating: p.text(`rating`).notNull(),
-  createdAt: p.timestamp(`timestamp`).defaultNow().notNull(),
+  skillId: s.text(`skillId`).notNull(),
+  rating: s.text(`rating`).notNull(),
+  createdAt: s.timestamp(`timestamp`).defaultNow().notNull(),
 });
 
 export const skillState = schema.table(
   `skillState`,
   {
-    id: p.text(`id`).primaryKey().$defaultFn(nanoid),
-    userId: p
+    id: s.text(`id`).primaryKey().$defaultFn(nanoid),
+    userId: s
       .text(`userId`)
       .references(() => user.id)
       .notNull(),
-    skillId: p.text(`skillId`).notNull(),
-    srs: p.json(`srs`),
-    dueAt: p.timestamp(`dueAt`).notNull(),
-    createdAt: p.timestamp(`createdAt`).defaultNow().notNull(),
+    skillId: s.text(`skillId`).notNull(),
+    srs: s.json(`srs`),
+    dueAt: s.timestamp(`dueAt`).notNull(),
+    createdAt: s.timestamp(`createdAt`).defaultNow().notNull(),
   },
-  (t) => [p.unique().on(t.userId, t.skillId)],
+  (t) => [s.unique().on(t.userId, t.skillId)],
+);
+
+export const pinyinInitialAssociation = schema.table(
+  `pinyinInitialAssociation`,
+  {
+    id: s.text(`id`).primaryKey().$defaultFn(nanoid),
+    userId: s
+      .text(`userId`)
+      .references(() => user.id)
+      .notNull(),
+    initial: s.text(`initial`).notNull(),
+    name: s.text(`name`).notNull(),
+    updatedAt: s.timestamp(`updatedAt`).defaultNow().notNull(),
+    createdAt: s.timestamp(`createdAt`).defaultNow().notNull(),
+  },
+  (t) => [s.unique().on(t.userId, t.initial)],
+);
+
+export const pinyinFinalAssociation = schema.table(
+  `pinyinFinalAssociation`,
+  {
+    id: s.text(`id`).primaryKey().$defaultFn(nanoid),
+    userId: s
+      .text(`userId`)
+      .references(() => user.id)
+      .notNull(),
+    final: s.text(`final`).notNull(),
+    name: s.text(`name`).notNull(),
+    updatedAt: s.timestamp(`updatedAt`).defaultNow().notNull(),
+    createdAt: s.timestamp(`createdAt`).defaultNow().notNull(),
+  },
+  (t) => [s.unique().on(t.userId, t.final)],
 );
 
 export const replicacheClientGroup = schema.table(`replicacheClientGroup`, {
-  id: p.text(`id`).primaryKey().$defaultFn(nanoid),
-  userId: p
+  id: s.text(`id`).primaryKey().$defaultFn(nanoid),
+  userId: s
     .text(`userId`)
     .references(() => user.id)
     .notNull(),
@@ -88,29 +120,29 @@ export const replicacheClientGroup = schema.table(`replicacheClientGroup`, {
    * Replicache requires that cookies are ordered within a client group. To
    * establish this order we simply keep a counter.
    */
-  cvrVersion: p.integer(`cvrVersion`).notNull().default(0),
-  updatedAt: p.timestamp(`timestamp`).defaultNow().notNull(),
+  cvrVersion: s.integer(`cvrVersion`).notNull().default(0),
+  updatedAt: s.timestamp(`timestamp`).defaultNow().notNull(),
 });
 
 export const replicacheClient = schema.table(`replicacheClient`, {
-  id: p.text(`id`).primaryKey().$defaultFn(nanoid),
-  clientGroupId: p
+  id: s.text(`id`).primaryKey().$defaultFn(nanoid),
+  clientGroupId: s
     .text(`clientGroupId`)
     .references(() => replicacheClientGroup.id)
     .notNull(),
-  lastMutationId: p.integer(`lastMutationId`).notNull(),
-  updatedAt: p.timestamp(`timestamp`).defaultNow().notNull(),
+  lastMutationId: s.integer(`lastMutationId`).notNull(),
+  updatedAt: s.timestamp(`timestamp`).defaultNow().notNull(),
 });
 
 export const replicacheMutation = schema.table(`replicacheMutation`, {
-  id: p.text(`id`).primaryKey().$defaultFn(nanoid),
-  clientId: p
+  id: s.text(`id`).primaryKey().$defaultFn(nanoid),
+  clientId: s
     .text(`clientId`)
     .references(() => replicacheClient.id)
     .notNull(),
-  mutation: p.json(`mutation`).notNull(),
-  success: p.boolean(),
-  processedAt: p.timestamp(`processedAt`).defaultNow().notNull(),
+  mutation: s.json(`mutation`).notNull(),
+  success: s.boolean(),
+  processedAt: s.timestamp(`processedAt`).defaultNow().notNull(),
 });
 
 /**
@@ -118,7 +150,7 @@ export const replicacheMutation = schema.table(`replicacheMutation`, {
  * sent to Replicache.
  */
 export const replicacheCvr = schema.table(`replicacheCvr`, {
-  id: p.text(`id`).primaryKey().$defaultFn(nanoid),
+  id: s.text(`id`).primaryKey().$defaultFn(nanoid),
   /**
    * Map of clientID->lastMutationID pairs, one for each client in the client
    * group.
@@ -127,7 +159,7 @@ export const replicacheCvr = schema.table(`replicacheCvr`, {
    * { <clientId>: <lastMutationId> }
    * ```
    */
-  lastMutationIds: p.json(`lastMutationIds`).notNull(),
+  lastMutationIds: s.json(`lastMutationIds`).notNull(),
   /**
    * For each entity visible to the user, map of key->version pairs, grouped by
    * table name.
@@ -136,6 +168,6 @@ export const replicacheCvr = schema.table(`replicacheCvr`, {
    * { <tableName>: { "<primaryKey>": "<version>:<replicacheId>" } }
    * ```
    */
-  entities: p.json(`entities`).notNull(),
-  createdAt: p.timestamp(`createdAt`).defaultNow().notNull(),
+  entities: s.json(`entities`).notNull(),
+  createdAt: s.timestamp(`createdAt`).defaultNow().notNull(),
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added Pinyin Initial and Final Association tables to support language learning mnemonic associations
	- Introduced new methods to set and manage Pinyin associations for users

- **Refactor**
	- Updated schema references and import aliases across multiple files
	- Renamed `SkillReview` interface to `SkillRating`

- **Database Changes**
	- Created new database tables for tracking Pinyin Initial and Final Associations
	- Added foreign key constraints linking associations to user accounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->