### PR TITLE
Minor refactoring

### DIFF
--- a/projects/app/src/__tests__/server/lib/replicache.test.ts
+++ b/projects/app/src/__tests__/server/lib/replicache.test.ts
@@ -132,7 +132,7 @@ void test(`push()`, async (t) => {
     },
   );
 
-  await txTest(`addSkillState() should insert to the db`, async (tx) => {
+  await txTest(`initSkillState() should insert to the db`, async (tx) => {
     const clientId = `clientid`;
     const clientGroupId = `clientgroupid`;
 
@@ -143,7 +143,7 @@ void test(`push()`, async (t) => {
     const mut = {
       id: 1,
       name: `addSkillState`,
-      args: r.addSkillState.marshalArgs({
+      args: r.initSkillState.marshalArgs({
         skill: {
           type: SkillType.EnglishToHanzi,
           hanzi: `我`,
@@ -198,7 +198,7 @@ void test(`push()`, async (t) => {
     const mut = {
       id: client.lastMutationId, // use the same ID
       name: `addSkillState`,
-      args: r.addSkillState.marshalArgs({
+      args: r.initSkillState.marshalArgs({
         skill: {
           type: SkillType.EnglishToHanzi,
           hanzi: `我`,

--- a/projects/app/src/components/ReplicacheContext.tsx
+++ b/projects/app/src/components/ReplicacheContext.tsx
@@ -91,7 +91,7 @@ export function ReplicacheProvider({ children }: React.PropsWithChildren) {
       },
       schema,
       {
-        async addSkillState(db, { skill, now }) {
+        async initSkillState(db, { skill, now }) {
           const exists = await db.skillState.has({ skill });
           if (!exists) {
             await db.skillState.set(

--- a/projects/app/src/data/rizzleSchema.ts
+++ b/projects/app/src/data/rizzleSchema.ts
@@ -155,10 +155,15 @@ export const skillState = r.entity(`s/[skill]`, {
   due: r.timestamp().alias(`d`).indexed(`byDue`),
 });
 
-export const addSkillState = r.mutator({
-  skill: rSkillId().alias(`s`),
-  now: r.timestamp().alias(`n`),
-});
+export const initSkillState = r
+  .mutator({
+    skill: rSkillId().alias(`s`),
+    now: r.timestamp().alias(`n`),
+  })
+  .alias(
+    // Original deprecated name, kept for compatibility.
+    `addSkillState`,
+  );
 
 export const reviewSkill = r.mutator({
   skill: rSkillId().alias(`s`),
@@ -195,7 +200,7 @@ export const setPinyinFinalAssociation = r.mutator({
 // --
 
 export const schema = {
-  addSkillState,
+  initSkillState,
   pinyinFinalAssociation,
   pinyinInitialAssociation,
   setPinyinInitialAssociation,

--- a/projects/app/src/server/lib/replicache.ts
+++ b/projects/app/src/server/lib/replicache.ts
@@ -581,7 +581,7 @@ export async function getClient(
 export const _mutate = makeDrizzleMutationHandler<typeof r.schema, Drizzle>(
   r.schema,
   {
-    async addSkillState(db, userId, { skill, now }) {
+    async initSkillState(db, userId, { skill, now }) {
       const skillId = r.rSkillId().marshal(skill);
       await db
         .insert(s.skillState)

--- a/projects/app/src/server/lib/replicache.ts
+++ b/projects/app/src/server/lib/replicache.ts
@@ -673,7 +673,7 @@ export async function computeCvrEntities(db: Drizzle, userId: string) {
       map: json_object_agg(
         s.skillRating.id,
         json_build_object({
-          skillId: s.skillState.skillId,
+          skill: sql<MarshaledSkillId>`${s.skillState.skillId}`,
           xmin: sql<string>`${s.skillState}.xmin`,
         }),
       ).as(`skillStateVersions`),
@@ -714,22 +714,15 @@ export async function computeCvrEntities(db: Drizzle, userId: string) {
   return {
     pinyinInitialAssociation: mapValues(
       result.pinyinInitialAssociation,
-      (v) =>
-        v.xmin +
-        `:` +
-        r.pinyinInitialAssociation.marshalKey({ initial: v.initial }),
+      (v) => v.xmin + `:` + r.pinyinInitialAssociation.marshalKey(v),
     ),
     pinyinFinalAssociation: mapValues(
       result.pinyinFinalAssociation,
-      (v) =>
-        v.xmin + `:` + r.pinyinFinalAssociation.marshalKey({ final: v.final }),
+      (v) => v.xmin + `:` + r.pinyinFinalAssociation.marshalKey(v),
     ),
     skillState: mapValues(
       result.skillState,
-      (v) =>
-        v.xmin +
-        `:` +
-        r.skillState.marshalKey({ skill: v.skillId as MarshaledSkillId }),
+      (v) => v.xmin + `:` + r.skillState.marshalKey(v),
     ),
     skillRating: mapValues(
       result.skillRating,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed `addSkillState` method to `initSkillState` across multiple components and test files
	- Updated method signatures and references to maintain backward compatibility
	- Simplified SQL representations and mapping functions in skill state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->