### PR TITLE
Try to fix inconsistent EAS fingerprinting

### DIFF
--- a/projects/app/package.json
+++ b/projects/app/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "./src/main.js",
   "type": "module",
+  "scripts": {},
   "dependencies": {
     "@expo/metro-runtime": "~4.0.0",
     "@haohaohow/lib": "workspace:*",


### PR DESCRIPTION
Attempting to fix the following diff:

```
{
  "op": "added",
  "addedSource": {
   "type": "contents",
   "id": "packageJson:scripts",
   "contents": {},
   "reasons": [
    "packageJson:scripts"
   ],
   "hash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
  }
 }
 ```

 I'm guessing it might not like that there's no `scripts` section in the
 `package.json` and some command is adding it and causing a diff. By including
 an empty one it might fix the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Prepared `package.json` for future script definitions by adding an empty scripts object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->