### PR TITLE
Increase API maxDuration to 25s

### DIFF
--- a/projects/app/vercel.json
+++ b/projects/app/vercel.json
@@ -4,6 +4,7 @@
   "devCommand": "",
   "functions": {
     "api/index.cjs": {
+      "maxDuration": 25,
       "runtime": "@vercel/node@3.2.29",
       "includeFiles": "dist/vercel/server/**"
     }


### PR DESCRIPTION
Previously it was the default (10s) and it would sometimes timeout for cold requests and give 504 error to clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated Vercel function configuration to allow a maximum execution duration of 25 seconds for the API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->