### PR TITLE
Fix EAS Build fingerprinting for expo-sqlite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,10 @@ Add the device to the provisioning profile:
 npx -y eas-cli build --profile=preview --platform=ios
 ```
 
+It's important that this is done using the interactive version of the command so
+that you can authenticate your Apple Developer account and have it synchronize
+the provisioning profile.
+
 ## Manually marking a Drizzle migration as "run"
 
 In local development it can be useful to merge together migrations without

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "haohaohow",
   "packageManager": "yarn@4.6.0",
   "workspaces": [
-    "./projects/app",
-    "./projects/emails",
-    "./projects/lib",
-    "./projects/static"
+    "projects/*"
   ],
   "devDependencies": {
     "@types/semver": "7.5.x",

--- a/projects/app/.fingerprintignore
+++ b/projects/app/.fingerprintignore
@@ -1,0 +1,4 @@
+# Fix a bug in expo-sqlite where running `pod install` mutates the `ios`
+# directory by copying in sqlite3.* files from the vendor directory which
+# ends up changing the fingerprint hash because local and EAS build server.
+**/expo-sqlite/ios/sqlite3.{c,h}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated CONTRIBUTING.md with clarification on using interactive commands for iOS device enrollment with `eas-cli`

- **Bug Fixes**
	- Added configuration to `.fingerprintignore` to resolve `expo-sqlite` package build inconsistencies with iOS builds

- **Chores**
	- Simplified workspace configuration in package.json to include all subdirectories within the projects directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->