### PR TITLE
Fix Sentry.init()

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -32,7 +32,6 @@ jobs:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           # <.env.test>
           EXPO_PUBLIC_REPLICACHE_LICENSE_KEY: HHH_TEST_LICENSE_KEY
-          EXPO_PUBLIC_SENTRY_DSN: HHH_TEST_DSN
           # </.env.test>
           # Magic "empty" tree https://jiby.tech/post/git-diff-empty-repo/, so
           # that all files are seen as "affected" by moon ci, and thus all CI

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,7 +99,6 @@ jobs:
     env:
       # <.env.test>
       EXPO_PUBLIC_REPLICACHE_LICENSE_KEY: HHH_TEST_LICENSE_KEY
-      EXPO_PUBLIC_SENTRY_DSN: HHH_TEST_DSN
       # </.env.test>
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_STATIC }}

--- a/projects/app/.env.test
+++ b/projects/app/.env.test
@@ -1,3 +1,2 @@
 # Keep in sync with Github workflows (search `<.env.test>`)
 EXPO_PUBLIC_REPLICACHE_LICENSE_KEY="HHH_TEST_LICENSE_KEY"
-EXPO_PUBLIC_SENTRY_DSN="HHH_TEST_DSN"

--- a/projects/app/api/index.cjs
+++ b/projects/app/api/index.cjs
@@ -1,3 +1,9 @@
+const Sentry = require(`@sentry/node`);
+
+Sentry.init({
+  dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
+});
+
 const { createRequestHandler } = require(`@expo/server/adapter/vercel`);
 
 module.exports = createRequestHandler({

--- a/projects/app/src/app/_layout.tsx
+++ b/projects/app/src/app/_layout.tsx
@@ -1,24 +1,11 @@
-import { getSessionId } from "@/components/auth";
-import { ReplicacheProvider } from "@/components/ReplicacheContext";
-import { sentryDsn } from "@/env";
-import { trpc } from "@/util/trpc";
-import {
-  DefaultTheme,
-  Theme as ReactNavigationTheme,
-  ThemeProvider,
-} from "@react-navigation/native";
+/* eslint-disable import/first */
+
+// ------------------------------
+// Sentry instrumentation setup for react-native (but not API routes).
+// ------------------------------
+
 import * as Sentry from "@sentry/react-native";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { HTTPHeaders, httpLink } from "@trpc/client";
-import { useFonts } from "expo-font";
-import { Image } from "expo-image";
-import { Slot, SplashScreen, useNavigationContainerRef } from "expo-router";
 import * as Updates from "expo-updates";
-import { cssInterop } from "nativewind";
-import { useEffect, useState } from "react";
-import { Platform, useColorScheme, View } from "react-native";
-import Animated from "react-native-reanimated";
-import "../global.css";
 
 // Via the guide: https://docs.expo.dev/guides/using-sentry/
 const manifest = Updates.manifest;
@@ -31,10 +18,34 @@ const updateGroup =
 const routingIntegration = Sentry.reactNavigationIntegration();
 
 Sentry.init({
-  enabled: !__DEV__,
-  dsn: sentryDsn,
+  dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
   integrations: [routingIntegration],
 });
+
+// ------------------------------
+// Continue on with the rest of the file as normal. It's important that
+// `Sentry.init()` comes first as it hooks into require()/import calls so it
+// needs to be very early on in the setup.
+// ------------------------------
+
+import { getSessionId } from "@/components/auth";
+import { ReplicacheProvider } from "@/components/ReplicacheContext";
+import { trpc } from "@/util/trpc";
+import {
+  DefaultTheme,
+  Theme as ReactNavigationTheme,
+  ThemeProvider,
+} from "@react-navigation/native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HTTPHeaders, httpLink } from "@trpc/client";
+import { useFonts } from "expo-font";
+import { Image } from "expo-image";
+import { Slot, SplashScreen, useNavigationContainerRef } from "expo-router";
+import { cssInterop } from "nativewind";
+import { useEffect, useState } from "react";
+import { Platform, useColorScheme, View } from "react-native";
+import Animated from "react-native-reanimated";
+import "../global.css";
 
 {
   const scope = Sentry.getCurrentScope();

--- a/projects/app/src/env.ts
+++ b/projects/app/src/env.ts
@@ -7,15 +7,3 @@ export const replicacheLicenseKey = nonEmptyString
   // The special value `HHH_TEST_LICENSE_KEY` swaps to the test key from replicache.
   .transform((x) => (x === `HHH_TEST_LICENSE_KEY` ? TEST_LICENSE_KEY : x))
   .parse(process.env.EXPO_PUBLIC_REPLICACHE_LICENSE_KEY);
-
-export const sentryDsn = nonEmptyString
-  // Always require a DSN to be set to force environment variables to be
-  // provided, but in the case of tests set it to an empty string to disable
-  // sending events to Sentry.
-  //
-  // > … if it is initialized with an empty DSN, the SDK will not send any data
-  // > over the network, such as captured exceptions.
-  //
-  // Source: https://docs.sentry.io/concepts/key-terms/dsn-explainer/
-  .transform((x) => (x === `HHH_TEST_DSN` ? `` : x))
-  .parse(process.env.EXPO_PUBLIC_SENTRY_DSN);

--- a/projects/app/src/server/lib/inngest.ts
+++ b/projects/app/src/server/lib/inngest.ts
@@ -1,12 +1,6 @@
-import { sentryDsn } from "@/env";
 import { sentryMiddleware } from "@inngest/middleware-sentry";
-import * as Sentry from "@sentry/node";
 import { Inngest } from "inngest";
 import { z } from "zod";
-
-Sentry.init({
-  dsn: sentryDsn,
-});
 
 // Create a client to send and receive events
 export const inngest = new Inngest({

--- a/projects/app/src/server/lib/trpc.ts
+++ b/projects/app/src/server/lib/trpc.ts
@@ -1,11 +1,6 @@
-import { sentryDsn } from "@/env";
 import * as Sentry from "@sentry/node";
 import { initTRPC, TRPCError } from "@trpc/server";
 import { Context } from "./trpcContext";
-
-Sentry.init({
-  dsn: sentryDsn,
-});
 
 // Avoid exporting the entire t-object since it's not very descriptive. For
 // instance, the use of a t variable is common in i18n libraries.


### PR DESCRIPTION
Previously it was called too late, and would cause problems with running the local expo dev server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Configuration Changes**
  - Removed Sentry DSN from various configuration files
  - Updated GitHub Actions workflow configurations

- **Environment Updates**
  - Removed `EXPO_PUBLIC_SENTRY_DSN` environment variable across multiple files
  - Added `HHH_VERCEL_PREVIEW` environment variable in GitHub Actions workflows

- **Dependency and Initialization**
  - Adjusted Sentry error tracking setup in application components
  - Removed Sentry initialization from server-side libraries

These changes primarily relate to environment configuration and error tracking setup, with no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->