### PR TITLE
Pin Vercel API server Node.js to 22.x

### DIFF
--- a/projects/app/api/package.json
+++ b/projects/app/api/package.json
@@ -5,6 +5,9 @@
     "@sentry/core": "^8.48.0",
     "@sentry/node": "^8.48.0"
   },
+  "engines": {
+    "node": "22.x"
+  },
   "packageManager": "pnpm@9.15.3",
   "pnpm": {
     "patchedDependencies": {


### PR DESCRIPTION
This should also make it visible to Renovate. There's still an issue of its version being inconsistent with the one for the workspace (but this is hard to fix since the tests need 23.x Node.js features).