### PR TITLE
Fix bad class instance spread

### DIFF
--- a/projects/app/src/__tests__/app/api/helpers.ts
+++ b/projects/app/src/__tests__/app/api/helpers.ts
@@ -35,16 +35,9 @@ export function testExpoServer(t: TestContext) {
     throw err;
   });
 
-  const _fetch = async (input: RequestInfo, init?: RequestInit) => {
-    const inputWithPrefixedUrl =
-      typeof input === `string`
-        ? `${SERVER_URL}${input}`
-        : {
-            ...input,
-            url: `${SERVER_URL}${input.url}`,
-          };
-    return await fetch(
-      inputWithPrefixedUrl,
+  const _fetch = async (input: string, init?: RequestInit) =>
+    await fetch(
+      `${SERVER_URL}${input}`,
       Object.assign(
         { ...init },
         {
@@ -55,7 +48,6 @@ export function testExpoServer(t: TestContext) {
         },
       ),
     );
-  };
 
   return {
     fetch: _fetch,


### PR DESCRIPTION
Fixes a warning in a new version of eslint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the internal `_fetch` function to accept only string inputs
	- Streamlined URL construction logic in test helper function

<!-- end of auto-generated comment: release notes by coderabbit.ai -->