### PR TITLE
Fix missing `Promise.allSettled`

### DIFF
--- a/projects/app/package.json
+++ b/projects/app/package.json
@@ -60,6 +60,7 @@
     "oslo": "^1.2.1",
     "pg": "^8.12.0",
     "pg-protocol": "^1.7.0",
+    "promise": "^8.3.0",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",
     "react-native": "0.76.5",

--- a/projects/app/src/app/_layout.tsx
+++ b/projects/app/src/app/_layout.tsx
@@ -40,6 +40,7 @@ Sentry.init({
 import { getSessionId } from "@/components/auth";
 import { ReplicacheProvider } from "@/components/ReplicacheContext";
 import { trpc } from "@/util/trpc";
+import { invariant } from "@haohaohow/lib/invariant";
 import {
   DefaultTheme,
   Theme as ReactNavigationTheme,
@@ -57,6 +58,15 @@ import Animated from "react-native-reanimated";
 import "../global.css";
 
 {
+  // Regression test for
+  // https://github.com/getsentry/sentry-react-native/issues/2851#issuecomment-1628559234.
+  // The problem happened when calling `Sentry.init` as it presumably resolved
+  // to an old version of 'promise'.
+  invariant(
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    Promise.allSettled != null,
+  );
+
   const scope = Sentry.getCurrentScope();
   scope.setTag(`expo-update-id`, Updates.updateId);
   scope.setTag(`expo-is-embedded-update`, Updates.isEmbeddedLaunch);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2645,6 +2645,7 @@ __metadata:
     pg-protocol: "npm:^1.7.0"
     prettier: "npm:^3.4.2"
     prettier-plugin-tailwindcss: "npm:^0.6.9"
+    promise: "npm:^8.3.0"
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
     react-native: "npm:0.76.5"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Added `promise` library version 8.3.0 to project dependencies

- **Error Handling**
	- Integrated additional error tracking checks for Sentry initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->