### PR TITLE
Allow setting mnemonic theme for a pinyin initial group

### DIFF
--- a/projects/app/drizzle/0009_pretty_morbius.sql
+++ b/projects/app/drizzle/0009_pretty_morbius.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "haohaohow"."pinyinInitialGroupTheme" (
+	"id" text PRIMARY KEY NOT NULL,
+	"userId" text NOT NULL,
+	"groupId" text NOT NULL,
+	"themeId" text NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "pinyinInitialGroupTheme_userId_groupId_unique" UNIQUE("userId","groupId")
+);
+--> statement-breakpoint
+ALTER TABLE "haohaohow"."pinyinInitialGroupTheme" ADD CONSTRAINT "pinyinInitialGroupTheme_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "haohaohow"."user"("id") ON DELETE no action ON UPDATE no action;

--- a/projects/app/drizzle/meta/0009_snapshot.json
+++ b/projects/app/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,723 @@
+{
+  "id": "0feafadd-4b42-4943-aaf8-14c3b8671c39",
+  "prevId": "7267e242-58f5-492b-aa8b-12dbb88469e0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "haohaohow.authOAuth2": {
+      "name": "authOAuth2",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerUserId": {
+          "name": "providerUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authOAuth2_userId_user_id_fk": {
+          "name": "authOAuth2_userId_user_id_fk",
+          "tableFrom": "authOAuth2",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authOAuth2_provider_providerUserId_unique": {
+          "name": "authOAuth2_provider_providerUserId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "providerUserId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.authSession": {
+      "name": "authSession",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authSession_userId_user_id_fk": {
+          "name": "authSession_userId_user_id_fk",
+          "tableFrom": "authSession",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.pinyinFinalAssociation": {
+      "name": "pinyinFinalAssociation",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final": {
+          "name": "final",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pinyinFinalAssociation_userId_user_id_fk": {
+          "name": "pinyinFinalAssociation_userId_user_id_fk",
+          "tableFrom": "pinyinFinalAssociation",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pinyinFinalAssociation_userId_final_unique": {
+          "name": "pinyinFinalAssociation_userId_final_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "final"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.pinyinInitialAssociation": {
+      "name": "pinyinInitialAssociation",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial": {
+          "name": "initial",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pinyinInitialAssociation_userId_user_id_fk": {
+          "name": "pinyinInitialAssociation_userId_user_id_fk",
+          "tableFrom": "pinyinInitialAssociation",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pinyinInitialAssociation_userId_initial_unique": {
+          "name": "pinyinInitialAssociation_userId_initial_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "initial"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.pinyinInitialGroupTheme": {
+      "name": "pinyinInitialGroupTheme",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "groupId": {
+          "name": "groupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "themeId": {
+          "name": "themeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pinyinInitialGroupTheme_userId_user_id_fk": {
+          "name": "pinyinInitialGroupTheme_userId_user_id_fk",
+          "tableFrom": "pinyinInitialGroupTheme",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pinyinInitialGroupTheme_userId_groupId_unique": {
+          "name": "pinyinInitialGroupTheme_userId_groupId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "groupId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.replicacheClient": {
+      "name": "replicacheClient",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientGroupId": {
+          "name": "clientGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMutationId": {
+          "name": "lastMutationId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "replicacheClient_clientGroupId_replicacheClientGroup_id_fk": {
+          "name": "replicacheClient_clientGroupId_replicacheClientGroup_id_fk",
+          "tableFrom": "replicacheClient",
+          "tableTo": "replicacheClientGroup",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "clientGroupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.replicacheClientGroup": {
+      "name": "replicacheClientGroup",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cvrVersion": {
+          "name": "cvrVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "replicacheClientGroup_userId_user_id_fk": {
+          "name": "replicacheClientGroup_userId_user_id_fk",
+          "tableFrom": "replicacheClientGroup",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.replicacheCvr": {
+      "name": "replicacheCvr",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastMutationIds": {
+          "name": "lastMutationIds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entities": {
+          "name": "entities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.replicacheMutation": {
+      "name": "replicacheMutation",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutation": {
+          "name": "mutation",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "replicacheMutation_clientId_replicacheClient_id_fk": {
+          "name": "replicacheMutation_clientId_replicacheClient_id_fk",
+          "tableFrom": "replicacheMutation",
+          "tableTo": "replicacheClient",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.skillRating": {
+      "name": "skillRating",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skillId": {
+          "name": "skillId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skillRating_userId_user_id_fk": {
+          "name": "skillRating_userId_user_id_fk",
+          "tableFrom": "skillRating",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.skillState": {
+      "name": "skillState",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skillId": {
+          "name": "skillId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "srs": {
+          "name": "srs",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dueAt": {
+          "name": "dueAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skillState_userId_user_id_fk": {
+          "name": "skillState_userId_user_id_fk",
+          "tableFrom": "skillState",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skillState_userId_skillId_unique": {
+          "name": "skillState_userId_skillId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "skillId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.user": {
+      "name": "user",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "haohaohow": "haohaohow"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/projects/app/drizzle/meta/_journal.json
+++ b/projects/app/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1736061761676,
       "tag": "0008_fancy_pet_avengers",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1737550964156,
+      "tag": "0009_pretty_morbius",
+      "breakpoints": true
     }
   ]
 }

--- a/projects/app/src/__tests__/dictionary/dictionary.test.ts
+++ b/projects/app/src/__tests__/dictionary/dictionary.test.ts
@@ -1,3 +1,4 @@
+import { PinyinInitialGroupId } from "#data/model.ts";
 import {
   allHsk1Words,
   allHsk2Words,
@@ -255,7 +256,9 @@ function splitPinyin(
 }
 
 interface PinyinChart {
-  initials: DeepReadonly<{ id: string; desc: string; initials: string[][] }[]>;
+  initials: DeepReadonly<
+    { id: PinyinInitialGroupId; desc: string; initials: string[][] }[]
+  >;
   finals: readonly PinyinProduction[];
   overrides?: DeepReadonly<Record<string, [initial: string, final: string]>>;
 }

--- a/projects/app/src/__tests__/server/lib/replicache.test.ts
+++ b/projects/app/src/__tests__/server/lib/replicache.test.ts
@@ -738,6 +738,7 @@ void test(`computeCvr()`, async (t) => {
           assert.deepEqual(await computeCvrEntities(tx, `1`, schema), {
             pinyinFinalAssociation: {},
             pinyinInitialAssociation: {},
+            pinyinInitialGroupTheme: {},
             skillState: {},
             skillRating: {},
           });
@@ -750,6 +751,7 @@ void test(`computeCvr()`, async (t) => {
         assert.deepEqual(await computeCvrEntities(tx, user.id, schema), {
           pinyinFinalAssociation: {},
           pinyinInitialAssociation: {},
+          pinyinInitialGroupTheme: {},
           skillState: {},
           skillRating: {},
         });
@@ -793,6 +795,7 @@ void test(`computeCvr()`, async (t) => {
         assert.deepEqual(await computeCvrEntities(tx, user1.id, schema), {
           pinyinFinalAssociation: {},
           pinyinInitialAssociation: {},
+          pinyinInitialGroupTheme: {},
           skillRating: {},
           skillState: {
             [user1SkillState.id]:
@@ -838,6 +841,7 @@ void test(`computeCvr()`, async (t) => {
         assert.deepEqual(await computeCvrEntities(tx, user1.id, schema), {
           pinyinFinalAssociation: {},
           pinyinInitialAssociation: {},
+          pinyinInitialGroupTheme: {},
           skillRating: {
             [user1SkillRating.id]:
               user1SkillRating.version +
@@ -888,6 +892,7 @@ void test(`computeCvr()`, async (t) => {
                 ),
             },
             pinyinInitialAssociation: {},
+            pinyinInitialGroupTheme: {},
             skillRating: {},
             skillState: {},
           });
@@ -931,6 +936,7 @@ void test(`computeCvr()`, async (t) => {
                   user1PinyinInitialAssociation,
                 ),
             },
+            pinyinInitialGroupTheme: {},
             skillRating: {},
             skillState: {},
           });

--- a/projects/app/src/app/(sidenav)/explore/mnemonics/index.tsx
+++ b/projects/app/src/app/(sidenav)/explore/mnemonics/index.tsx
@@ -60,6 +60,18 @@ export default function MnemonicsPage() {
     },
   );
 
+  const initialGroupThemes = useRizzleQuery(
+    [MnemonicsPage.name, `initialGroupThemes`],
+    async (r, tx) => {
+      return await fromAsync(r.query.pinyinInitialGroupTheme.scan(tx)).then(
+        (x) =>
+          new Map(
+            x.map(([key, value]) => [key.groupId, value.themeId] as const),
+          ),
+      );
+    },
+  );
+
   return (
     <ScrollView
       className="flex-1"
@@ -115,10 +127,13 @@ export default function MnemonicsPage() {
 
             <View className="gap-3.5 lg:gap-4">
               {Object.entries(query.data.initials).map(
-                ([, { initials, desc }], i) => (
+                ([, { initials, desc, id }], i) => (
                   <Fragment key={desc}>
-                    <View className="flex-0">
+                    <View className="flex-0 flex-row gap-2">
                       <Text className="text-md text-text">{desc}</Text>
+                      <Text className="text-md text-primary-8">
+                        {initialGroupThemes.data?.get(id) ?? `no theme`}
+                      </Text>
                     </View>
                     <View className="flex-0 flex-row flex-wrap gap-3.5">
                       {initials.map(([initial, ...alts]) => (

--- a/projects/app/src/components/ReplicacheContext.tsx
+++ b/projects/app/src/components/ReplicacheContext.tsx
@@ -137,6 +137,9 @@ export function ReplicacheProvider({ children }: React.PropsWithChildren) {
         async setPinyinFinalAssociation(tx, { final, name }) {
           await tx.pinyinFinalAssociation.set({ final }, { name });
         },
+        async setPinyinInitialGroupTheme(tx, { groupId, themeId }) {
+          await tx.pinyinInitialGroupTheme.set({ groupId }, { themeId });
+        },
       },
     );
   }, [auth.isAuthenticated, pushMutate, pullMutate]);

--- a/projects/app/src/data/model.ts
+++ b/projects/app/src/data/model.ts
@@ -1,5 +1,23 @@
 import { Rating } from "@/util/fsrs";
 
+export enum PinyinInitialGroupId {
+  Basic,
+  _i,
+  _u,
+  _v,
+  Null,
+  Everything,
+}
+
+export enum MnemonicThemeId {
+  AnimalSpecies,
+  GreekMythologyCharacter,
+  MythologyCharacter,
+  WesternCultureFamousMen,
+  WesternCultureFamousWomen,
+  WesternMythologyCharacter,
+}
+
 export enum SrsType {
   Null,
   FsrsFourPointFive,

--- a/projects/app/src/data/rizzleSchema.ts
+++ b/projects/app/src/data/rizzleSchema.ts
@@ -2,7 +2,13 @@ import { Rating } from "@/util/fsrs";
 import { invalid, r, RizzleCustom } from "@/util/rizzle";
 import memoize from "lodash/memoize";
 import { z } from "zod";
-import { Skill, SkillType, SrsType } from "./model";
+import {
+  MnemonicThemeId,
+  PinyinInitialGroupId,
+  Skill,
+  SkillType,
+  SrsType,
+} from "./model";
 
 export const rSkillType = r.enum(SkillType, {
   [SkillType.RadicalToEnglish]: `re`,
@@ -23,6 +29,24 @@ export const rFsrsRating = r.enum(Rating, {
   [Rating.Hard]: `2`,
   [Rating.Good]: `3`,
   [Rating.Easy]: `4`,
+});
+
+export const rPinyinInitialGroupId = r.enum(PinyinInitialGroupId, {
+  [PinyinInitialGroupId.Basic]: `basic`,
+  [PinyinInitialGroupId._i]: `-i`,
+  [PinyinInitialGroupId._u]: `-u`,
+  [PinyinInitialGroupId._v]: `-ü`,
+  [PinyinInitialGroupId.Null]: `∅`,
+  [PinyinInitialGroupId.Everything]: `everything`,
+});
+
+export const rMnemonicThemeId = r.enum(MnemonicThemeId, {
+  [MnemonicThemeId.AnimalSpecies]: `AnimalSpecies`,
+  [MnemonicThemeId.GreekMythologyCharacter]: `GreekMythologyCharacter`,
+  [MnemonicThemeId.MythologyCharacter]: `MythologyCharacter`,
+  [MnemonicThemeId.WesternCultureFamousMen]: `WesternCultureFamousMen`,
+  [MnemonicThemeId.WesternCultureFamousWomen]: `WesternCultureFamousWomen`,
+  [MnemonicThemeId.WesternMythologyCharacter]: `WesternMythologyCharacter`,
 });
 
 // Skill ID e.g. `he:好`
@@ -251,10 +275,19 @@ export const v4 = {
   //
   pinyinFinalAssociation: v3.pinyinFinalAssociation,
   pinyinInitialAssociation: v3.pinyinInitialAssociation,
+  pinyinInitialGroupTheme: r.entity(`pigt/[groupId]`, {
+    groupId: rPinyinInitialGroupId,
+    themeId: rMnemonicThemeId.alias(`t`),
+  }),
 
   // Mutators
   setPinyinInitialAssociation: v3.setPinyinInitialAssociation,
   setPinyinFinalAssociation: v3.setPinyinFinalAssociation,
+  setPinyinInitialGroupTheme: r.mutator({
+    groupId: rPinyinInitialGroupId.alias(`g`),
+    themeId: rMnemonicThemeId.alias(`t`),
+    now: r.timestamp().alias(`n`),
+  }),
   reviewSkill: v3.reviewSkill,
   initSkillState: v3.initSkillState,
 };

--- a/projects/app/src/dictionary/dictionary.ts
+++ b/projects/app/src/dictionary/dictionary.ts
@@ -1,3 +1,4 @@
+import { rMnemonicThemeId, rPinyinInitialGroupId } from "@/data/rizzleSchema";
 import { deepReadonly } from "@/util/collections";
 import { invariant } from "@haohaohow/lib/invariant";
 import memoize from "lodash/memoize";
@@ -38,7 +39,7 @@ export const loadMnemonicThemeChoices = memoize(async () =>
       (x) =>
         new Map(
           Object.entries(x).map(([k, v]) => [
-            k,
+            rMnemonicThemeId.unmarshal(k),
             new Map(
               Object.entries(v).map(([k2, v2]) => [
                 k2,
@@ -64,7 +65,7 @@ const pinyinChartSchema = z
   .object({
     initials: z.array(
       z.object({
-        id: z.string(),
+        id: rPinyinInitialGroupId.getUnmarshal(),
         desc: z.string(),
         initials: z.array(z.union([z.string(), z.array(z.string())])),
       }),

--- a/projects/app/src/dictionary/hhPinyinChart.asset.json
+++ b/projects/app/src/dictionary/hhPinyinChart.asset.json
@@ -1,6 +1,6 @@
 {
 "initials":[{
-  "id": "default",
+  "id": "everything",
   "desc": "default",
   "initials": [["_",""],"b","bi","bu","c","ch","chu","cu","d","di","du","f","fu","g","gu","h","hu","ji","ju","k","ku","l","li","lu","lü","m","mi","mu","n","ni","nu","nü","p","pi","pu","qi","qu","r","ru","s","sh","shu","su","t","ti","tu","w","xi","xu",["y","y","yi"],"yu","z","zh","zhu","zu"]
 }],

--- a/projects/app/src/dictionary/standardPinyinChart.asset.json
+++ b/projects/app/src/dictionary/standardPinyinChart.asset.json
@@ -1,6 +1,6 @@
 {
 "initials":[{
-  "id": "default",
+  "id": "everything",
   "desc": "default",
   "initials": [["∅",""],"b","p","m","f","d","t","n","l","g","k","h","j","q","x","zh","ch","sh","r","z","c","s"]
 }],

--- a/projects/app/src/server/schema.ts
+++ b/projects/app/src/server/schema.ts
@@ -1,4 +1,4 @@
-import { Skill } from "@/data/model";
+import { MnemonicThemeId, PinyinInitialGroupId, Skill } from "@/data/model";
 import * as r from "@/data/rizzleSchema";
 import * as s from "drizzle-orm/pg-core";
 import { customType } from "drizzle-orm/pg-core";
@@ -21,6 +21,36 @@ const skill = (name: string) => {
       return marshaler.unmarshal(value);
     },
     toDriver(value): r.MarshaledSkill {
+      return marshaler.marshal(value);
+    },
+  })(name);
+};
+
+const mnemonicThemeId = (name: string) => {
+  const marshaler = r.rMnemonicThemeId;
+  return customType<{ data: MnemonicThemeId; driverData: string }>({
+    dataType() {
+      return `text`;
+    },
+    fromDriver(value): MnemonicThemeId {
+      return marshaler.unmarshal(value);
+    },
+    toDriver(value): string {
+      return marshaler.marshal(value);
+    },
+  })(name);
+};
+
+const pinyinInitialGroupId = (name: string) => {
+  const marshaler = r.rPinyinInitialGroupId;
+  return customType<{ data: PinyinInitialGroupId; driverData: string }>({
+    dataType() {
+      return `text`;
+    },
+    fromDriver(value): PinyinInitialGroupId {
+      return marshaler.unmarshal(value);
+    },
+    toDriver(value): string {
       return marshaler.marshal(value);
     },
   })(name);
@@ -126,6 +156,22 @@ export const pinyinFinalAssociation = schema.table(
     createdAt: s.timestamp(`createdAt`).defaultNow().notNull(),
   },
   (t) => [s.unique().on(t.userId, t.final)],
+);
+
+export const pinyinInitialGroupTheme = schema.table(
+  `pinyinInitialGroupTheme`,
+  {
+    id: s.text(`id`).primaryKey().$defaultFn(nanoid),
+    userId: s
+      .text(`userId`)
+      .references(() => user.id)
+      .notNull(),
+    groupId: pinyinInitialGroupId(`groupId`).notNull(),
+    themeId: mnemonicThemeId(`themeId`).notNull(),
+    updatedAt: s.timestamp(`updatedAt`).defaultNow().notNull(),
+    createdAt: s.timestamp(`createdAt`).defaultNow().notNull(),
+  },
+  (t) => [s.unique().on(t.userId, t.groupId)],
 );
 
 export const replicacheClientGroup = schema.table(`replicacheClientGroup`, {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
    - Added support for Pinyin initial group themes
    - Introduced new theme categories for mnemonics, including Animal Species, Greek Mythology, and Western Culture themes
    - Enhanced mnemonic and initial group data with theme information

- **Improvements**
    - Updated data models to support more precise theme and group identification
    - Improved type safety for theme and group identifiers

- **Technical Updates**
    - Expanded schema to include new theme-related entities and enumerations
    - Updated data handling for more robust theme management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->