### PR TITLE
Remove deprecated @types/eslint__js

### DIFF
--- a/projects/app/package.json
+++ b/projects/app/package.json
@@ -100,7 +100,6 @@
     "@types/color": "^3",
     "@types/debug": "^4 <=4.3.x",
     "@types/eslint": "^9 <=9.13.x",
-    "@types/eslint__js": "^8.42.3",
     "@types/fontkit": "2.0.x",
     "@types/lodash": "4.17.x",
     "@types/node": "patch:@types/node@patch%3A@types/node@npm%253A22.10.2%23~/.yarn/patches/@types-node-npm-22.10.2-572466b048.patch%3A%3Aversion=22.10.2&hash=819d81#~/.yarn/patches/@types-node-patch-8935673d40.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2606,7 +2606,6 @@ __metadata:
     "@types/color": "npm:^3"
     "@types/debug": "npm:^4 <=4.3.x"
     "@types/eslint": "npm:^9 <=9.13.x"
-    "@types/eslint__js": "npm:^8.42.3"
     "@types/fontkit": "npm:2.0.x"
     "@types/lodash": "npm:4.17.x"
     "@types/node": "patch:@types/node@patch%3A@types/node@npm%253A22.10.2%23~/.yarn/patches/@types-node-npm-22.10.2-572466b048.patch%3A%3Aversion=22.10.2&hash=819d81#~/.yarn/patches/@types-node-patch-8935673d40.patch"
@@ -5507,22 +5506,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint@npm:*, @types/eslint@npm:^9 <=9.13.x":
+"@types/eslint@npm:^9 <=9.13.x":
   version: 9.6.1
   resolution: "@types/eslint@npm:9.6.1"
   dependencies:
     "@types/estree": "npm:*"
     "@types/json-schema": "npm:*"
   checksum: 10c0/69ba24fee600d1e4c5abe0df086c1a4d798abf13792d8cfab912d76817fe1a894359a1518557d21237fbaf6eda93c5ab9309143dee4c59ef54336d1b3570420e
-  languageName: node
-  linkType: hard
-
-"@types/eslint__js@npm:^8.42.3":
-  version: 8.42.3
-  resolution: "@types/eslint__js@npm:8.42.3"
-  dependencies:
-    "@types/eslint": "npm:*"
-  checksum: 10c0/ccc5180b92155929a089ffb03ed62625216dcd5e46dd3197c6f82370ce8b52c7cb9df66c06b0a3017995409e023bc9eafe5a3f009e391960eacefaa1b62d9a56
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Cleaned up our development configuration by removing an unnecessary dependency. This improvement streamlines our internal toolchain and enhances maintainability. While it refines our build process behind the scenes, it does not alter any visible functionality for end-users. The update contributes to a cleaner codebase and a smoother development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->