### PR TITLE
make replicacheClientGroup.schemaVersion non-null

### DIFF
--- a/projects/app/drizzle/0014_living_chamber.sql
+++ b/projects/app/drizzle/0014_living_chamber.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "haohaohow"."replicacheClientGroup" ALTER COLUMN "schemaVersion" SET NOT NULL;

--- a/projects/app/drizzle/meta/0014_snapshot.json
+++ b/projects/app/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,885 @@
+{
+  "id": "1ed3a863-7731-412c-8c47-b42dc3cc9b00",
+  "prevId": "ef1ee88b-41f9-415f-98c7-6ce50474af94",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "haohaohow.authOAuth2": {
+      "name": "authOAuth2",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerUserId": {
+          "name": "providerUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authOAuth2_userId_user_id_fk": {
+          "name": "authOAuth2_userId_user_id_fk",
+          "tableFrom": "authOAuth2",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authOAuth2_provider_providerUserId_unique": {
+          "name": "authOAuth2_provider_providerUserId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "providerUserId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.authSession": {
+      "name": "authSession",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authSession_userId_user_id_fk": {
+          "name": "authSession_userId_user_id_fk",
+          "tableFrom": "authSession",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.pinyinFinalAssociation": {
+      "name": "pinyinFinalAssociation",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final": {
+          "name": "final",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pinyinFinalAssociation_userId_user_id_fk": {
+          "name": "pinyinFinalAssociation_userId_user_id_fk",
+          "tableFrom": "pinyinFinalAssociation",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pinyinFinalAssociation_userId_final_unique": {
+          "name": "pinyinFinalAssociation_userId_final_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "final"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.pinyinInitialAssociation": {
+      "name": "pinyinInitialAssociation",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial": {
+          "name": "initial",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pinyinInitialAssociation_userId_user_id_fk": {
+          "name": "pinyinInitialAssociation_userId_user_id_fk",
+          "tableFrom": "pinyinInitialAssociation",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pinyinInitialAssociation_userId_initial_unique": {
+          "name": "pinyinInitialAssociation_userId_initial_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "initial"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.pinyinInitialGroupTheme": {
+      "name": "pinyinInitialGroupTheme",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "groupId": {
+          "name": "groupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "themeId": {
+          "name": "themeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pinyinInitialGroupTheme_userId_user_id_fk": {
+          "name": "pinyinInitialGroupTheme_userId_user_id_fk",
+          "tableFrom": "pinyinInitialGroupTheme",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pinyinInitialGroupTheme_userId_groupId_unique": {
+          "name": "pinyinInitialGroupTheme_userId_groupId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "groupId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.remoteSync": {
+      "name": "remoteSync",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remoteUrl": {
+          "name": "remoteUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remoteClientGroupId": {
+          "name": "remoteClientGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remoteProfileId": {
+          "name": "remoteProfileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remoteSessionId": {
+          "name": "remoteSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastSyncedMutationIds": {
+          "name": "lastSyncedMutationIds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pulledClientIds": {
+          "name": "pulledClientIds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remoteSync_userId_user_id_fk": {
+          "name": "remoteSync_userId_user_id_fk",
+          "tableFrom": "remoteSync",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "remoteSync_remoteUrl_userId_unique": {
+          "name": "remoteSync_remoteUrl_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "remoteUrl",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.replicacheClient": {
+      "name": "replicacheClient",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientGroupId": {
+          "name": "clientGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMutationId": {
+          "name": "lastMutationId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "replicacheClient_clientGroupId_index": {
+          "name": "replicacheClient_clientGroupId_index",
+          "columns": [
+            {
+              "expression": "clientGroupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "replicacheClient_clientGroupId_replicacheClientGroup_id_fk": {
+          "name": "replicacheClient_clientGroupId_replicacheClientGroup_id_fk",
+          "tableFrom": "replicacheClient",
+          "tableTo": "replicacheClientGroup",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "clientGroupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.replicacheClientGroup": {
+      "name": "replicacheClientGroup",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schemaVersion": {
+          "name": "schemaVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cvrVersion": {
+          "name": "cvrVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "replicacheClientGroup_userId_index": {
+          "name": "replicacheClientGroup_userId_index",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "replicacheClientGroup_userId_user_id_fk": {
+          "name": "replicacheClientGroup_userId_user_id_fk",
+          "tableFrom": "replicacheClientGroup",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.replicacheCvr": {
+      "name": "replicacheCvr",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastMutationIds": {
+          "name": "lastMutationIds",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entities": {
+          "name": "entities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.replicacheMutation": {
+      "name": "replicacheMutation",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutation": {
+          "name": "mutation",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "replicacheMutation_clientId_index": {
+          "name": "replicacheMutation_clientId_index",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "replicacheMutation_clientId_replicacheClient_id_fk": {
+          "name": "replicacheMutation_clientId_replicacheClient_id_fk",
+          "tableFrom": "replicacheMutation",
+          "tableTo": "replicacheClient",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.skillRating": {
+      "name": "skillRating",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skillId": {
+          "name": "skillId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skillRating_userId_skillId_index": {
+          "name": "skillRating_userId_skillId_index",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skillId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skillRating_userId_user_id_fk": {
+          "name": "skillRating_userId_user_id_fk",
+          "tableFrom": "skillRating",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.skillState": {
+      "name": "skillState",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skillId": {
+          "name": "skillId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "srs": {
+          "name": "srs",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dueAt": {
+          "name": "dueAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skillState_userId_user_id_fk": {
+          "name": "skillState_userId_user_id_fk",
+          "tableFrom": "skillState",
+          "tableTo": "user",
+          "schemaTo": "haohaohow",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skillState_userId_skillId_unique": {
+          "name": "skillState_userId_skillId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "skillId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "haohaohow.user": {
+      "name": "user",
+      "schema": "haohaohow",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "haohaohow": "haohaohow"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/projects/app/drizzle/meta/_journal.json
+++ b/projects/app/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1741069864284,
       "tag": "0013_careful_betty_brant",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1741070728394,
+      "tag": "0014_living_chamber",
+      "breakpoints": true
     }
   ]
 }

--- a/projects/app/src/server/lib/replicache.ts
+++ b/projects/app/src/server/lib/replicache.ts
@@ -610,7 +610,7 @@ export async function putClient(db: Drizzle, client: ClientRecord) {
 export interface ClientGroupRecord {
   id: string;
   userId: string;
-  schemaVersion: string | null;
+  schemaVersion: string;
   cvrVersion: number;
 }
 

--- a/projects/app/src/server/schema.ts
+++ b/projects/app/src/server/schema.ts
@@ -162,7 +162,7 @@ export const replicacheClientGroup = schema.table(
      * The schema version that this client group is using, it's set when the first
      * push is made and can be used when syncing mutations between servers.
      */
-    schemaVersion: s.text(),
+    schemaVersion: s.text().notNull(),
     /**
      * Replicache requires that cookies are ordered within a client group. To
      * establish this order we simply keep a counter.

--- a/projects/app/test/server/lib/replicache.test.ts
+++ b/projects/app/test/server/lib/replicache.test.ts
@@ -67,6 +67,7 @@ void test(`push()`, async (t) => {
                 id: `1`,
                 userId: user1.id,
                 cvrVersion: 1,
+                schemaVersion: schema.version,
               },
             ])
             .returning();
@@ -181,7 +182,7 @@ void test(`push()`, async (t) => {
         // Create a client group
         const [clientGroup] = await tx
           .insert(s.replicacheClientGroup)
-          .values([{ userId: user.id }])
+          .values([{ userId: user.id, schemaVersion: schema.version }])
           .returning();
         invariant(clientGroup != null);
 
@@ -226,7 +227,7 @@ void test(`push()`, async (t) => {
         // Create a client group
         const [clientGroup] = await tx
           .insert(s.replicacheClientGroup)
-          .values([{ userId: user.id }])
+          .values([{ userId: user.id, schemaVersion: schema.version }])
           .returning();
         invariant(clientGroup != null);
 
@@ -264,7 +265,7 @@ void test(`push()`, async (t) => {
           // Create a client group
           const [clientGroup] = await tx
             .insert(s.replicacheClientGroup)
-            .values([{ userId: user.id }])
+            .values([{ userId: user.id, schemaVersion: schema.version }])
             .returning();
           invariant(clientGroup != null);
 
@@ -387,7 +388,7 @@ void test(`pull()`, async (t) => {
           // Create a client group
           const [clientGroup] = await tx
             .insert(s.replicacheClientGroup)
-            .values([{ userId: user.id }])
+            .values([{ userId: user.id, schemaVersion: schema.version }])
             .returning();
           invariant(clientGroup != null);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved data consistency by enforcing that all client group records include a valid version identifier.
  
- **Tests**
  - Updated test cases to verify the inclusion of the required version value, ensuring robust validation and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->