### PR TITLE
make hanzi buttons not bold for better readability

### DIFF
--- a/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
@@ -649,6 +649,7 @@ const ChoiceButton = ({
       textClassName={choiceButtonText({
         length:
           text.length <= 20 ? `short` : text.length <= 40 ? `medium` : `long`,
+        className: choice.type === `hanzi` ? `font-normal` : undefined,
       })}
     >
       {text}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Fine-tuned the appearance of answer buttons in the quiz interface. Now, when an answer corresponds to a specific category, it is rendered with a regular font weight to improve visual clarity. This adjustment enhances the overall user experience by making some answers stand out, contributing to a more engaging and accessible quiz interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->