### PR TITLE
dim non-selected buttons on one-pair quiz

### DIFF
--- a/projects/app/src/client/ui/AnswerButton.tsx
+++ b/projects/app/src/client/ui/AnswerButton.tsx
@@ -15,7 +15,12 @@ import { AnimatedPressable } from "./AnimatedPressable";
 import { PropsOf } from "./types";
 import { hapticImpactIfMobile } from "./util";
 
-export type AnswerButtonState = `default` | `selected` | `success` | `error`;
+export type AnswerButtonState =
+  | `default`
+  | `selected`
+  | `success`
+  | `error`
+  | `dimmed`;
 
 export type AnswerButtonProps = {
   children?: ViewProps[`children`];
@@ -74,6 +79,7 @@ export const AnswerButton = forwardRef<
   useEffect(() => {
     if (stateChanged) {
       switch (state) {
+        case `dimmed`:
         case `default`: {
           setBgFilled(false);
           bgScale.set(0.5);
@@ -214,6 +220,7 @@ const text = tv({
   variants: {
     state: {
       default: `text-text`,
+      dimmed: `text-primary-9`,
       selected: `text-accent-9`,
       success: `text-accent-9`,
       error: `text-accent-9`,
@@ -226,6 +233,7 @@ const roundedRect = tv({
   variants: {
     state: {
       default: ``,
+      dimmed: ``,
       selected: ``,
       success: `success-theme`,
       error: `danger-theme`,

--- a/projects/app/src/client/ui/DevLozenge.tsx
+++ b/projects/app/src/client/ui/DevLozenge.tsx
@@ -2,7 +2,7 @@ import { Text } from "react-native";
 
 export const DevLozenge = () => {
   return (
-    <Text className="rounded bg-lime-9 px-1 py-0.5 text-[10px] font-bold text-primary-3 text-text">
+    <Text className="rounded bg-lime-9 px-1 py-0.5 text-[10px] font-bold text-background text-primary-3">
       DEV
     </Text>
   );

--- a/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
@@ -42,7 +42,7 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { tv } from "tailwind-variants";
-import { AnswerButton } from "./AnswerButton";
+import { AnswerButton, AnswerButtonState } from "./AnswerButton";
 import { HanziText } from "./HanziText";
 import { NewSkillModal } from "./NewSkillModal";
 import { RectButton2 } from "./RectButton2";
@@ -256,6 +256,7 @@ export const QuizDeckOneCorrectPairQuestion = memo(
         {flag?.type === QuestionFlagType.NewSkill ? (
           <NewSkillModal skill={question.answer.a.skill} />
         ) : null}
+
         {flag == null ? null : <FlagText flag={flag} />}
         <View>
           <Text className="text-xl font-bold text-text">{prompt}</Text>
@@ -275,19 +276,31 @@ export const QuizDeckOneCorrectPairQuestion = memo(
               <View className="flex-1 flex-row gap-[28px]" key={i}>
                 <ChoiceButton
                   choice={a.a}
-                  selected={a === selectedAAnswer}
+                  state={
+                    selectedAAnswer === undefined
+                      ? `default`
+                      : a === selectedAAnswer
+                        ? `selected`
+                        : `dimmed`
+                  }
                   onPress={() => {
                     if (!showResult) {
-                      setSelectedAAnswer(a);
+                      setSelectedAAnswer((x) => (x === a ? undefined : a));
                     }
                   }}
                 />
                 <ChoiceButton
                   choice={b.b}
-                  selected={b === selectedBAnswer}
+                  state={
+                    selectedBAnswer === undefined
+                      ? `default`
+                      : b === selectedBAnswer
+                        ? `selected`
+                        : `dimmed`
+                  }
                   onPress={() => {
                     if (!showResult) {
-                      setSelectedBAnswer(b);
+                      setSelectedBAnswer((x) => (x === b ? undefined : b));
                     }
                   }}
                 />
@@ -607,11 +620,11 @@ const SubmitButton = forwardRef<
 });
 
 const ChoiceButton = ({
-  selected,
+  state,
   choice,
   onPress,
 }: {
-  selected: boolean;
+  state: AnswerButtonState;
   choice: OneCorrectPairQuestionChoice;
   onPress: (choice: OneCorrectPairQuestionChoice) => void;
 }) => {
@@ -662,7 +675,7 @@ const ChoiceButton = ({
   return (
     <AnswerButton
       onPress={handlePress}
-      state={selected ? `selected` : `default`}
+      state={state}
       className="flex-1"
       textClassName={choiceButtonText({
         length:


### PR DESCRIPTION
users were getting confused about whether they need to select one pair or multiple pairs of answers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new visual state to answer buttons, enhancing feedback by differentiating a "dimmed" mode.
  - Improved quiz answer selection with toggle functionality, allowing users to deselect choices easily.

- **Style**
  - Refined text styling in interface elements for clearer visual emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->