### PR TITLE
add some styling for gloss hints

### DIFF
--- a/projects/app/src/client/ui/GlossHint.tsx
+++ b/projects/app/src/client/ui/GlossHint.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+import { Text, View } from "react-native";
+import { Hhhmark } from "./Hhhmark";
+
+export const GlossHint = ({
+  glossHint,
+  headlineClassName,
+  explanationClassName,
+  hideExplanation = false,
+}: {
+  glossHint: string;
+  headlineClassName?: string;
+  explanationClassName?: string;
+  hideExplanation?: boolean;
+}) => {
+  const parts = useMemo(() => {
+    const lines = glossHint.split(`\n`);
+    return { headline: lines[0], explanation: lines[1] };
+  }, [glossHint]);
+
+  return (
+    <View className="gap-1">
+      {parts.headline == null ? null : (
+        <Text className={headlineClassName}>
+          <Hhhmark source={`"${parts.headline}"`} />
+        </Text>
+      )}
+      {parts.explanation == null || hideExplanation ? null : (
+        <Text className={explanationClassName}>
+          <Hhhmark source={parts.explanation} />
+        </Text>
+      )}
+    </View>
+  );
+};

--- a/projects/app/src/client/ui/HanziWordModal.tsx
+++ b/projects/app/src/client/ui/HanziWordModal.tsx
@@ -3,6 +3,8 @@ import { HanziWord } from "@/data/model";
 import { hanziFromHanziWord, splitCharacters } from "@/dictionary/dictionary";
 import { useMemo } from "react";
 import { ScrollView, Text, View } from "react-native";
+import { GlossHint } from "./GlossHint";
+import { Hhhmark } from "./Hhhmark";
 import { PageSheetModal } from "./PageSheetModal";
 import { RectButton2 } from "./RectButton2";
 
@@ -46,25 +48,27 @@ export const HanziWordModal = ({
                   </Text>
                 </View>
 
-                {hanziWordSkillData.data.glossHint == null ? null : (
-                  <View className="gap-1">
-                    <Text className="text-xs uppercase text-primary-10">
-                      Hint
-                    </Text>
-                    <Text className="text-md font-karla text-text">
-                      {hanziWordSkillData.data.glossHint}
-                    </Text>
-                  </View>
-                )}
-
                 {hanziWordSkillData.data.pinyin == null ? null : (
                   <View className="gap-1">
                     <Text className="text-xs uppercase text-primary-10">
                       Pinyin
                     </Text>
-                    <Text className="text-md font-karla text-text">
+                    <Text className="font-karla text-text">
                       {hanziWordSkillData.data.pinyin.join(`, `)}
                     </Text>
+                  </View>
+                )}
+
+                {hanziWordSkillData.data.glossHint == null ? null : (
+                  <View className="gap-1">
+                    <Text className="text-xs uppercase text-primary-10">
+                      Hint
+                    </Text>
+                    <GlossHint
+                      glossHint={hanziWordSkillData.data.glossHint}
+                      headlineClassName="font-karla text-text"
+                      explanationClassName="font-karla text-text opacity-80"
+                    />
                   </View>
                 )}
 
@@ -73,7 +77,7 @@ export const HanziWordModal = ({
                     <Text className="text-xs uppercase text-primary-10">
                       Gloss
                     </Text>
-                    <Text className="text-md font-karla text-text">
+                    <Text className="font-karla text-text">
                       {hanziWordSkillData.data.gloss.join(`, `)}
                     </Text>
                   </View>
@@ -83,8 +87,8 @@ export const HanziWordModal = ({
                   <Text className="text-xs uppercase text-primary-10">
                     Definition
                   </Text>
-                  <Text className="text-md font-karla text-text">
-                    {hanziWordSkillData.data.definition}
+                  <Text className="font-karla text-text">
+                    <Hhhmark source={hanziWordSkillData.data.definition} />
                   </Text>
                 </View>
               </View>

--- a/projects/app/src/client/ui/Hhhmark.tsx
+++ b/projects/app/src/client/ui/Hhhmark.tsx
@@ -3,7 +3,40 @@ import { Text } from "react-native";
 
 export const Hhhmark = ({ source }: { source: string }) => {
   const rendered = useMemo(() => {
-    return source.replaceAll(`'`, `’`).replaceAll(/"([^"]*)"/g, `“$1”`);
+    const result = source.replaceAll(`'`, `’`).replaceAll(/"([^"]*)"/g, `“$1”`);
+
+    // Handle bold text by replacing **text** with <Text className="font-bold">text</Text>
+    const boldHandled = result.split(/\*\*(.*?)\*\*/g).map((part, index) =>
+      index % 2 === 1 ? (
+        <Text
+          key={`bold-${index}`}
+          className="rounded bg-accent-10 px-1 font-medium tracking-tighter text-primary-4"
+        >
+          {part}
+        </Text>
+      ) : (
+        part
+      ),
+    );
+
+    const italicHandled = boldHandled.map((part, index) =>
+      typeof part === `string`
+        ? part.split(/\*(.*?)\*/g).map((subPart, subIndex) => {
+            return subIndex % 2 === 1 ? (
+              <Text
+                key={`medium-${index}-${subIndex}`}
+                className="font-medium text-accent-10"
+              >
+                {subPart}
+              </Text>
+            ) : (
+              subPart
+            );
+          })
+        : part,
+    );
+
+    return italicHandled;
   }, [source]);
 
   return <Text>{rendered}</Text>;

--- a/projects/app/src/client/ui/NewSkillModal.tsx
+++ b/projects/app/src/client/ui/NewSkillModal.tsx
@@ -4,6 +4,7 @@ import { hanziFromHanziWord, splitCharacters } from "@/dictionary/dictionary";
 import { Image } from "expo-image";
 import { useMemo, useState } from "react";
 import { ScrollView, Text, View } from "react-native";
+import { GlossHint } from "./GlossHint";
 import { PageSheetModal } from "./PageSheetModal";
 import { RectButton2 } from "./RectButton2";
 
@@ -73,18 +74,18 @@ const NewHanziToEnglishSkillContent = ({
         <Text className="text-text">Not implemented</Text>
       ) : (
         <>
-          <View className="success-theme flex-row items-center gap-2 self-center">
-            <Image
-              source={require(`@/assets/icons/plant-filled.svg`)}
-              className="my-[-0px] h-[24px] w-[24px] flex-shrink text-accent-10"
-              tintColor="currentColor"
-            />
-            <Text className="text-md font-bold uppercase text-accent-10">
-              New Word
-            </Text>
-          </View>
+          <View className="mb-8 gap-8">
+            <View className="success-theme flex-row items-center gap-2 self-center">
+              <Image
+                source={require(`@/assets/icons/plant-filled.svg`)}
+                className="my-[-0px] h-[24px] w-[24px] flex-shrink text-accent-10"
+                tintColor="currentColor"
+              />
+              <Text className="text-md font-bold uppercase text-accent-10">
+                New Word
+              </Text>
+            </View>
 
-          <View className="my-4 gap-4">
             <View className="items-center gap-2">
               <View className="flex-row gap-1">
                 {characters.map((character) => (
@@ -102,11 +103,11 @@ const NewHanziToEnglishSkillContent = ({
             </View>
 
             {hanziWordSkillData.data.glossHint == null ? null : (
-              <View className="gap-1">
-                <Text className="text-center font-karla text-lg text-primary-11">
-                  {hanziWordSkillData.data.glossHint}
-                </Text>
-              </View>
+              <GlossHint
+                glossHint={hanziWordSkillData.data.glossHint}
+                headlineClassName="flex-column text-center font-karla text-2xl text-primary-11"
+                explanationClassName="flex-column text-center font-karla text-lg leading-normal text-primary-10"
+              />
             )}
           </View>
         </>

--- a/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
@@ -40,6 +40,7 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { tv } from "tailwind-variants";
+import { GlossHint } from "./GlossHint";
 import { HanziText } from "./HanziText";
 import { HanziWordModal } from "./HanziWordModal";
 import { Hhhmark } from "./Hhhmark";
@@ -529,10 +530,14 @@ const HanziWordToEnglishSkillAnswer = ({
       </Pressable>
 
       {includeHint && meaning.glossHint != null ? (
-        <Text className="leading-snug text-accent-10">
-          <Hhhmark source={meaning.glossHint} />
-        </Text>
+        <GlossHint
+          glossHint={meaning.glossHint}
+          hideExplanation
+          headlineClassName="leading-snug text-accent-10"
+          explanationClassName="leading-snug text-accent-9"
+        />
       ) : null}
+
       {showModal ? (
         <HanziWordModal
           hanziWord={skill.hanziWord}

--- a/projects/app/src/dictionary/dictionary.asset.json
+++ b/projects/app/src/dictionary/dictionary.asset.json
@@ -1671,7 +1671,7 @@
 ["正式:formal",{"gloss":["formal","official"],"pinyin":["zhèng shì"],"example":"他的正式服装很得体。","partOfSpeech":"adjective","definition":"Describes something that is formal or relates to official matters."}],
 ["正是:exactly",{"gloss":["exactly"],"pinyin":["zhèng shì"],"example":"这正是我们需要的。","partOfSpeech":"adverb","definition":"Used to emphasize precise accuracy or exactness."}],
 ["正确:correct",{"gloss":["correct","right"],"pinyin":["zhèng què"],"example":"这个答案是正确的。","partOfSpeech":"adjective","definition":"Free from error; in accordance with fact or truth."}],
-["此:this",{"gloss":["this"],"pinyin":["cǐ"],"example":"此事非常重要。","partOfSpeech":"pronoun","definition":"Refers to something close by or just mentioned; equivalent to 'this' in English."}],
+["此:this",{"gloss":["this"],"pinyin":["cǐ"],"example":"此事非常重要。","partOfSpeech":"pronoun","definition":"Refers to something close by or just mentioned; equivalent to 'this' in English.","glossHint":"Stop! **This** is my spoon!\nImagine someone pointing at a *匕 (spoon)* and telling someone else to *止 (stop)* because it belongs to them."}],
 ["步:step",{"gloss":["step","pace"],"pinyin":["bù"],"example":"他迈出了坚定的步伐。","partOfSpeech":"noun","definition":"A single movement of the foot while walking or running."}],
 ["武:military",{"gloss":["military"],"pinyin":["wǔ"],"example":"他对军事武器很感兴趣。","partOfSpeech":"noun","definition":"Related to the army or armed forces, from the Ancient form depicting marching (止) with a weapon (戈)."}],
 ["武器:weapon",{"gloss":["weapon"],"pinyin":["wǔ qì"],"example":"他携带了一些武器。","partOfSpeech":"noun","definition":"A thing designed or used for inflicting bodily harm or physical damage."}],

--- a/projects/app/test/dictionary/dictionary.test.ts
+++ b/projects/app/test/dictionary/dictionary.test.ts
@@ -178,7 +178,7 @@ await test(`hanzi word meaning glossHint lint`, async () => {
     // no double space
     /  /.exec(x) != null ||
     // no new lines
-    /\n/.exec(x) != null ||
+    // /\n/.exec(x) != null ||
     // doesn't exceed word limit
     (x.match(/\s+/g)?.length ?? 0) > maxSpaces;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new gloss hint display that cleanly separates headlines from explanations with customizable styling.
	- Enhanced text formatting to support bold and italic styles for improved visual clarity.
	- Updated hint presentation across screens with refined labels (e.g., showing Pinyin), improved spacing, and enriched dictionary entries with additional gloss details.

- **Tests**
	- Adjusted validation to now allow newline characters in gloss hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->