### PR TITLE
stop sentry making 504 timeouts on uncaught rejections

### DIFF
--- a/projects/app/api/index.cjs
+++ b/projects/app/api/index.cjs
@@ -3,7 +3,12 @@ const { captureConsoleIntegration } = require(`@sentry/core`);
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN, // Must be provided at runtime.
-  integrations: [captureConsoleIntegration()],
+  integrations: [
+    captureConsoleIntegration(),
+    // If there's an unhandled rejection then crash the process rather than
+    // hanging indefinitely as this is more suitable for serverless environments.
+    Sentry.onUnhandledRejectionIntegration({ mode: `strict` }),
+  ],
   tracesSampleRate: 1, // Keep in sync with the other Sentry.init()
   profilesSampleRate: 1,
 });


### PR DESCRIPTION
Node normally exits if there's an uncaught rejection, but Sentry attaches an uncaught rejection handler that stops the process from exiting so Vercel thinks the process is still running until it eventually hits the timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling to promptly address unexpected issues, preventing system hang-ups and ensuring a more stable experience—especially in serverless deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->