### PR TITLE
add max 4s between choices for quiz timer

### DIFF
--- a/projects/app/src/client/hooks.ts
+++ b/projects/app/src/client/hooks.ts
@@ -73,13 +73,18 @@ export function documentEventListenerEffect<K extends keyof DocumentEventMap>(
 export function useMultiChoiceQuizTimer() {
   const startTime = useMemo(() => Date.now(), []);
   const [endTime, setEndTime] = useState<number>();
+  const maxTimeBetweenChoices = 4000;
 
   const recordChoice = useCallback((correct: boolean) => {
-    if (correct) {
-      setEndTime((end) => end ?? Date.now());
-    } else {
-      setEndTime(undefined);
-    }
+    setEndTime((end) =>
+      correct
+        ? end == null
+          ? Date.now()
+          : Date.now() - end <= maxTimeBetweenChoices
+            ? end
+            : undefined
+        : undefined,
+    );
   }, []);
 
   return {

--- a/projects/app/test/client/ui/hooks.test.tsx
+++ b/projects/app/test/client/ui/hooks.test.tsx
@@ -5,7 +5,7 @@ import test from "node:test";
 await test(`${useMultiChoiceQuizTimer.name} suite`, async (t) => {
   await t.test(
     `records time correctly for correct and incorrect choices`,
-    async () => {
+    async (t) => {
       t.mock.timers.enable({ apis: [`Date`] });
 
       const { result } = renderHook(() => useMultiChoiceQuizTimer());
@@ -58,4 +58,31 @@ await test(`${useMultiChoiceQuizTimer.name} suite`, async (t) => {
       expect(result.current.endTime).toBe(300);
     },
   );
+
+  await t.test(`resets if more than 4s between choices`, async (t) => {
+    t.mock.timers.enable({ apis: [`Date`] });
+
+    const { result } = renderHook(() => useMultiChoiceQuizTimer());
+
+    // Simulate 100ms elapsed
+    t.mock.timers.tick(100);
+
+    // Record the first correct choice
+    act(() => {
+      result.current.recordChoice(true);
+    });
+
+    // Simulate 4.1s elapsed
+    t.mock.timers.tick(10_000);
+
+    // Should not reset because no additional choices were made
+    expect(result.current.endTime).toBe(100);
+
+    // Choosing another option should reset the timer because more than 4s have passed.
+    act(() => {
+      result.current.recordChoice(true);
+    });
+
+    expect(result.current.endTime).toBeUndefined();
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the quiz timer so that it now maintains a consistent timing state for quick successive answers and resets correctly for delayed responses.
- **Tests**
  - Expanded test coverage to ensure the timer behaves as expected during rapid and slow response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->