### PR TITLE
fix PinyinText rendering taking full width

### DIFF
--- a/projects/app/src/client/ui/HanziText.tsx
+++ b/projects/app/src/client/ui/HanziText.tsx
@@ -55,7 +55,7 @@ export const PinyinText = ({
 };
 
 const pinyinText = tv({
-  base: `text-base/none text-primary-9 w-full text-center`,
+  base: `text-base/none text-primary-9`,
   variants: {
     accented: {
       true: `text-accent-10 opacity-80`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the styling of pinyin text display by removing full-width and centered alignment. The new, streamlined style applies a standard text size with a primary color, offering a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->