### PR TITLE
fix Again ratings with FSRS

### DIFF
--- a/projects/app/src/client/query.ts
+++ b/projects/app/src/client/query.ts
@@ -16,7 +16,7 @@ import {
   skillReviewQueue,
 } from "@/data/skills";
 import { allHsk1HanziWords, lookupHanziWord } from "@/dictionary/dictionary";
-import { fsrsIsIntroduced, fsrsIsLearned } from "@/util/fsrs";
+import { fsrsIsLearned } from "@/util/fsrs";
 import { useQuery } from "@tanstack/react-query";
 import { add } from "date-fns/add";
 import { interval } from "date-fns/interval";
@@ -57,10 +57,7 @@ export async function questionsForReview2(
 export function flagsForSrsState(
   srsState: SrsState | undefined,
 ): QuestionFlag | undefined {
-  if (
-    srsState?.type !== SrsType.FsrsFourPointFive ||
-    !fsrsIsIntroduced(srsState)
-  ) {
+  if (srsState?.type !== SrsType.FsrsFourPointFive) {
     return {
       type: QuestionFlagType.NewSkill,
     };

--- a/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
@@ -127,7 +127,6 @@ export const QuizDeckOneCorrectPairQuestion = memo(
           computeSkillRating({
             skill: answer.skill,
             correct: isCorrect,
-            hadPreviousMistake: flag?.type === QuestionFlagType.PreviousMistake,
             durationMs,
           }),
         ];

--- a/projects/app/test/data/skills.test.ts
+++ b/projects/app/test/data/skills.test.ts
@@ -494,7 +494,6 @@ await test(`${computeSkillRating.name} suite`, async () => {
       skill,
       durationMs,
       correct: true,
-      hadPreviousMistake: true,
     });
     assert.partialDeepStrictEqual(rating, { skill, durationMs });
   });
@@ -502,23 +501,12 @@ await test(`${computeSkillRating.name} suite`, async () => {
   await test(`${SkillType.HanziWordToEnglish} suites`, async () => {
     const skill = `he:我:i`;
 
-    await test(`gives Hard rating for correct answer after previous mistake regardless of duration`, async () => {
-      const rating = computeSkillRating({
-        skill,
-        durationMs: 1000,
-        correct: true,
-        hadPreviousMistake: true,
-      });
-      assert.equal(rating.rating, Rating.Hard);
-    });
-
     await test(`gives rating based on duration`, async () => {
       {
         const { rating } = computeSkillRating({
           skill,
           durationMs: 1000,
           correct: true,
-          hadPreviousMistake: false,
         });
         assert.equal(rating, Rating.Easy);
       }
@@ -528,7 +516,6 @@ await test(`${computeSkillRating.name} suite`, async () => {
           skill,
           durationMs: 6000,
           correct: true,
-          hadPreviousMistake: false,
         });
         assert.equal(rating, Rating.Good);
       }
@@ -538,7 +525,6 @@ await test(`${computeSkillRating.name} suite`, async () => {
           skill,
           durationMs: 11_000,
           correct: true,
-          hadPreviousMistake: false,
         });
         assert.equal(rating, Rating.Hard);
       }


### PR DESCRIPTION
Stability now decreases after Again rating (previously it stayed the same). This was a bug when implementing the algorithm.

As a result removed the forced "Hard" rating after an "Again" rating, and removed the notion of "isFsrsIntroduced" since the way mistake tracking is implemented no longer created "Again" ratings for skills that have never been introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced updated evaluation icons for distinguishing different levels of performance and error types during quizzes.
- **Refactor**
  - Streamlined the logic for determining new skills and computing ratings by removing redundant conditions.
  - Adjusted review scheduling to provide more immediate and predictable feedback.
  - Refined stability calculations with improved rounding and constraints for a more consistent learning experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->