### PR TITLE
add hsk2 to review queue

### DIFF
--- a/projects/app/src/app/(sidenav)/learn/history/index.tsx
+++ b/projects/app/src/app/(sidenav)/learn/history/index.tsx
@@ -1,4 +1,4 @@
-import { hsk1SkillReview } from "@/client/query";
+import { targetSkillsReviewQueue } from "@/client/query";
 import { useRizzleQueryPaged } from "@/client/ui/ReplicacheContext";
 import { SkillType } from "@/data/model";
 import {
@@ -27,7 +27,7 @@ import { ScrollView, Text, View } from "react-native";
 export default function HistoryPage() {
   const data2Query = useRizzleQueryPaged(
     [HistoryPage.name, `hsk1SkillReview`],
-    (r) => hsk1SkillReview(r),
+    (r) => targetSkillsReviewQueue(r),
   );
 
   const skillRatingsQuery = useRizzleQueryPaged(

--- a/projects/app/test/client/query.test.ts
+++ b/projects/app/test/client/query.test.ts
@@ -1,7 +1,7 @@
 import {
   computeSkillReviewQueue,
   flagsForSrsState,
-  hsk1SkillReview,
+  targetSkillsReviewQueue,
 } from "#client/query.ts";
 import {
   HanziText,
@@ -20,12 +20,12 @@ import test from "node:test";
 import { parseRelativeTimeShorthand } from "../data/helpers";
 import { testReplicacheOptions } from "../util/rizzleHelpers";
 
-await test(`${hsk1SkillReview.name} suite`, async () => {
+await test(`${targetSkillsReviewQueue.name} suite`, async () => {
   await test(`returns everything when no skills have state`, async () => {
     await using rizzle = r.replicache(testReplicacheOptions(), v7, v7Mutators);
 
     // Sanity check that there should be a bunch in the queue
-    const skills = await hsk1SkillReview(rizzle);
+    const skills = await targetSkillsReviewQueue(rizzle);
     assert.ok(skills.length > 100);
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the skill review queue to include both HSK1 and HSK2 vocabulary, allowing users to review a broader range of skills.

- **Bug Fixes**
  - Updated terminology and queries throughout the app to reflect the inclusion of HSK2 vocabulary in skill reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->