### PR TITLE
add new eslint-rules project

### DIFF
--- a/projects/app/eslint.config.mjs
+++ b/projects/app/eslint.config.mjs
@@ -1,4 +1,5 @@
 import { FlatCompat } from "@eslint/eslintrc";
+import haohaohowPlugin from "@haohaohow/eslint-rules";
 import inngestPlugin from "@inngest/eslint-plugin";
 import stylisticPlugin from "@stylistic/eslint-plugin";
 import drizzlePlugin from "eslint-plugin-drizzle";
@@ -24,6 +25,7 @@ export default tseslint.config(
     // note - intentionally uses computed syntax to make it easy to sort the keys
     plugins: {
       [`@expoCodeImports`]: tseslint.plugin, // an extra scope for no-restricted-imports so they don't clobber other configs
+      [`@haohaohow`]: haohaohowPlugin,
       [`@inngest`]: inngestPlugin,
       [`@stylistic`]: stylisticPlugin,
       [`@typescript-eslint`]: tseslint.plugin,
@@ -255,6 +257,11 @@ export default tseslint.config(
       "unicorn/prevent-abbreviations": `off`, // abbreviations are fine
       "unicorn/no-nested-ternary": `off`, // nested ternaries are not so bad
       "unicorn/filename-case": `off`, // using camelCase for filenames
+
+      //
+      // @haohaohow/eslint-rules
+      //
+      "@haohaohow/reanimated-default-name": `error`,
     },
   },
 

--- a/projects/app/package.json
+++ b/projects/app/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~4.0.1",
+    "@haohaohow/eslint-rules": "workspace:*",
     "@haohaohow/lib": "workspace:*",
     "@inngest/middleware-sentry": "^0.1.1",
     "@lottiefiles/dotlottie-react": "^0.6.5",

--- a/projects/app/src/app/(sidenav)/learn/index.tsx
+++ b/projects/app/src/app/(sidenav)/learn/index.tsx
@@ -16,7 +16,7 @@ import { differenceInCalendarDays } from "date-fns/differenceInCalendarDays";
 import { sub } from "date-fns/sub";
 import { Link } from "expo-router";
 import { ScrollView, Text, View } from "react-native";
-import Animated, { FadeIn } from "react-native-reanimated";
+import Reanimated, { FadeIn } from "react-native-reanimated";
 import { tv } from "tailwind-variants";
 
 export default function IndexPage() {
@@ -173,7 +173,7 @@ export default function IndexPage() {
         </View>
       ) : (
         <>
-          <Animated.View
+          <Reanimated.View
             entering={FadeIn}
             style={{ alignSelf: `stretch`, alignItems: `center` }}
           >
@@ -282,9 +282,9 @@ export default function IndexPage() {
                 </Link>
               </View>
             </View>
-          </Animated.View>
+          </Reanimated.View>
 
-          <Animated.View
+          <Reanimated.View
             entering={FadeIn}
             style={{ alignSelf: `stretch`, alignItems: `center` }}
           >
@@ -306,7 +306,7 @@ export default function IndexPage() {
                 </RectButton2>
               </Link>
             </View>
-          </Animated.View>
+          </Reanimated.View>
         </>
       )}
     </ScrollView>

--- a/projects/app/src/app/(website)/_layout.web.tsx
+++ b/projects/app/src/app/(website)/_layout.web.tsx
@@ -4,7 +4,7 @@ import { invariant } from "@haohaohow/lib/invariant";
 import { Image } from "expo-image";
 import { Link, Slot } from "expo-router";
 import { ScrollView, View } from "react-native";
-import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
+import Reanimated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { tv } from "tailwind-variants";
 import { useIntersectionObserver } from "usehooks-ts";
 
@@ -39,7 +39,7 @@ export default function WebsiteLayout() {
 
             {isBodyGetStartedVisible ? null : (
               <View className="flex-1 flex-row items-center justify-end gap-2">
-                <Animated.View
+                <Reanimated.View
                   entering={FadeIn.duration(100)}
                   exiting={FadeOut.duration(100)}
                 >
@@ -52,7 +52,7 @@ export default function WebsiteLayout() {
                       Get Started
                     </RectButton2>
                   </Link>
-                </Animated.View>
+                </Reanimated.View>
               </View>
             )}
           </View>

--- a/projects/app/src/app/_layout.tsx
+++ b/projects/app/src/app/_layout.tsx
@@ -25,7 +25,7 @@ import { Stack, useNavigationContainerRef } from "expo-router";
 import { cssInterop } from "nativewind";
 import { useEffect, useState } from "react";
 import { Platform, useColorScheme, View } from "react-native";
-import Animated from "react-native-reanimated";
+import Reanimated from "react-native-reanimated";
 import "../global.css";
 
 // NativeWind adapters for third party components
@@ -34,7 +34,7 @@ import "../global.css";
 cssInterop(Image, {
   className: { target: `style`, nativeStyleToProp: { color: `tintColor` } },
 });
-cssInterop(Animated.View, { className: `style` });
+cssInterop(Reanimated.View, { className: `style` });
 
 import * as AppleAuthentication from "expo-apple-authentication";
 import Head from "expo-router/head";

--- a/projects/app/src/client/ui/AnimatedPressable.tsx
+++ b/projects/app/src/client/ui/AnimatedPressable.tsx
@@ -1,6 +1,6 @@
 import { cssInterop } from "nativewind";
 import { Pressable } from "react-native";
-import Animated from "react-native-reanimated";
+import Reanimated from "react-native-reanimated";
 
-export const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+export const AnimatedPressable = Reanimated.createAnimatedComponent(Pressable);
 cssInterop(AnimatedPressable, { className: `style` });

--- a/projects/app/src/client/ui/PageSheetModal.tsx
+++ b/projects/app/src/client/ui/PageSheetModal.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useEffect, useMemo, useState } from "react";
 import { Modal, Platform, PressableProps, View } from "react-native";
-import Animated, {
+import Reanimated, {
   Easing,
   Extrapolation,
   interpolate,
@@ -171,12 +171,12 @@ const WebImpl = ({
         style={[animatedBackgroundStyle]}
         onPress={onBackgroundPress}
       >
-        <Animated.View
+        <Reanimated.View
           className={`max-h-full w-full max-w-[500px] rounded-xl lg:max-h-[80vh] lg:w-[500px] bg-${backdropColor}`}
           style={[animatedContentStyle]}
         >
           {children(api)}
-        </Animated.View>
+        </Reanimated.View>
       </AnimatedPressable>
     </Modal>
   );

--- a/projects/app/src/client/ui/QuizProgressBar2.tsx
+++ b/projects/app/src/client/ui/QuizProgressBar2.tsx
@@ -2,7 +2,7 @@ import { makeRange } from "@/util/collections";
 import { LinearGradient } from "expo-linear-gradient";
 import { useEffect, useMemo, useState } from "react";
 import { LayoutChangeEvent, LayoutRectangle, View } from "react-native";
-import Animated, {
+import Reanimated, {
   Easing,
   SharedValue,
   useAnimatedStyle,
@@ -159,7 +159,7 @@ export const QuizProgressBar2 = ({ progress }: { progress: number }) => {
             })}
 
             {/* Fill bar */}
-            <Animated.View
+            <Reanimated.View
               className="flex-1 overflow-hidden"
               style={[
                 fillAnimStyles,
@@ -182,7 +182,7 @@ export const QuizProgressBar2 = ({ progress }: { progress: number }) => {
                   width: layout?.width,
                 }}
               />
-            </Animated.View>
+            </Reanimated.View>
           </View>
 
           {/* Ticks over the fill bar */}
@@ -218,7 +218,7 @@ const MinorTick = ({
   const animStyles = useTickAnimStyles({ axis, n, size: 5, fillSv });
 
   return (
-    <Animated.View
+    <Reanimated.View
       className="absolute top-1/2 rounded-full bg-[white]"
       style={animStyles}
     />
@@ -229,7 +229,7 @@ const MinorTickBg = ({ n, axis }: { axis: Axis; n: number }) => {
   const animStyles = useTickAnimStyles({ axis, n, size: 3 });
 
   return (
-    <Animated.View
+    <Reanimated.View
       className="absolute top-1/2 rounded-full bg-[white] opacity-50"
       style={animStyles}
     />
@@ -262,11 +262,11 @@ const MajorTick = ({
 
   return (
     <>
-      <Animated.View
+      <Reanimated.View
         className="absolute top-1/2 rounded-full bg-[#3F4CF5]"
         style={bgAnimStyles}
       />
-      <Animated.View
+      <Reanimated.View
         className="absolute left-1/2 top-1/2 rounded-full bg-[white]"
         style={dotAnimStyles}
       />
@@ -280,11 +280,11 @@ const MajorTickBg = ({ n, axis }: { axis: Axis; n: number }) => {
 
   return (
     <>
-      <Animated.View
+      <Reanimated.View
         className="absolute top-1/2 rounded-full bg-primary-7"
         style={bgAnimStyles}
       />
-      <Animated.View
+      <Reanimated.View
         className="absolute left-1/2 top-1/2 rounded-full bg-[white] opacity-50"
         style={dotAnimStyles}
       />

--- a/projects/app/src/client/ui/SplashScreen.tsx
+++ b/projects/app/src/client/ui/SplashScreen.tsx
@@ -4,7 +4,7 @@ import * as ExpoSplashScreen from "expo-splash-screen";
 import LottieView from "lottie-react-native";
 import { useEffect, useRef, useState } from "react";
 import { Platform, View } from "react-native";
-import Animated, { FadeOut } from "react-native-reanimated";
+import Reanimated, { FadeOut } from "react-native-reanimated";
 
 const isExpoGo =
   Constants.executionEnvironment === ExecutionEnvironment.StoreClient;
@@ -71,7 +71,7 @@ export const SplashScreen = ({}: { children?: never }) => {
   }
 
   return (
-    <Animated.View
+    <Reanimated.View
       exiting={FadeOut}
       className="absolute bottom-0 left-0 right-0 top-0"
     >
@@ -91,6 +91,6 @@ export const SplashScreen = ({}: { children?: never }) => {
           source={require(`@/assets/lottie/splash.lottie.json`)}
         />
       </View>
-    </Animated.View>
+    </Reanimated.View>
   );
 };

--- a/projects/app/src/client/ui/TextAnswerButton.tsx
+++ b/projects/app/src/client/ui/TextAnswerButton.tsx
@@ -1,7 +1,7 @@
 import { characterCount } from "@/dictionary/dictionary";
 import { ElementRef, forwardRef, useEffect, useMemo, useState } from "react";
 import { Pressable, Text, View } from "react-native";
-import Animated, {
+import Reanimated, {
   Easing,
   runOnJS,
   useAnimatedReaction,
@@ -163,7 +163,7 @@ export const TextAnswerButton = forwardRef<
       style={pressableAnimatedStyle}
       className={pressableClass({ flat, state, inFlexRowParent, className })}
     >
-      <Animated.View
+      <Reanimated.View
         style={bgAnimatedStyle}
         className={bgAnimatedClass({ state })}
       />

--- a/projects/app/tsconfig.json
+++ b/projects/app/tsconfig.json
@@ -26,16 +26,19 @@
   "exclude": [],
   "references": [
     {
+      "path": "./api"
+    },
+    {
+      "path": "./bin"
+    },
+    {
       "path": "./src"
     },
     {
       "path": "./test"
     },
     {
-      "path": "./api"
-    },
-    {
-      "path": "./bin"
+      "path": "../eslint-rules"
     },
     {
       "path": "../lib"

--- a/projects/eslint-rules/index.cjs
+++ b/projects/eslint-rules/index.cjs
@@ -1,0 +1,7 @@
+const reanimatedDefaultName = require("./reanimated-default-name.cjs");
+
+module.exports = {
+  rules: {
+    "reanimated-default-name": reanimatedDefaultName,
+  },
+};

--- a/projects/eslint-rules/moon.yml
+++ b/projects/eslint-rules/moon.yml
@@ -1,0 +1,8 @@
+tasks:
+  test:
+    command: node --test --test-reporter=spec --import tsx "'**/*.test.{js,cjs}'"
+    inputs:
+      - "!dist/"
+      - "**/*"
+    env:
+      NODE_OPTIONS: --experimental-vm-modules $NODE_OPTIONS

--- a/projects/eslint-rules/package.json
+++ b/projects/eslint-rules/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@haohaohow/eslint-rules",
+  "main": "index.cjs",
+  "type": "module",
+  "exports": {
+    ".": "./index.cjs"
+  },
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "eslint": "^9.13.0"
+  },
+  "private": true
+}

--- a/projects/eslint-rules/reanimated-default-name.cjs
+++ b/projects/eslint-rules/reanimated-default-name.cjs
@@ -1,0 +1,75 @@
+/**
+ * @typedef {import('eslint').Rule.RuleContext} RuleContext
+ * @typedef {import('eslint').Rule.Node} Node
+ * @typedef {import('estree').ImportDeclaration} ImportDeclaration
+ * @typedef {import('eslint').Rule.RuleModule} RuleModule
+ */
+
+/** @type {RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce default import from react-native-reanimated to be named Reanimated",
+    },
+    fixable: "code",
+    schema: [], // no options
+  },
+
+  /**
+   * @param {RuleContext} context
+   */
+  create(context) {
+    return {
+      /**
+       * @param {ImportDeclaration} node
+       */
+      ImportDeclaration(node) {
+        if (
+          node.source.value === "react-native-reanimated" &&
+          node.specifiers.some(
+            (specifier) =>
+              specifier.type === "ImportDefaultSpecifier" &&
+              specifier.local.name !== "Reanimated",
+          )
+        ) {
+          const badSpecifier = node.specifiers.find(
+            (s) =>
+              s.type === "ImportDefaultSpecifier" &&
+              s.local.name !== "Reanimated",
+          );
+
+          if (badSpecifier) {
+            context.report({
+              node: badSpecifier,
+              message: `Default import from "react-native-reanimated" must be named "Reanimated".`,
+              fix(fixer) {
+                const sourceCode = context.getSourceCode();
+                const references = sourceCode.getDeclaredVariables(node);
+
+                const fixes = [
+                  fixer.replaceText(badSpecifier.local, "Reanimated"),
+                ];
+
+                references.forEach((variable) => {
+                  variable.references.forEach((ref) => {
+                    if (ref.identifier.name === badSpecifier.local.name) {
+                      fixes.push(
+                        fixer.replaceText(ref.identifier, "Reanimated"),
+                      );
+                    }
+                  });
+                });
+
+                return fixes;
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+module.exports = rule;

--- a/projects/eslint-rules/reanimated-default-name.test.cjs
+++ b/projects/eslint-rules/reanimated-default-name.test.cjs
@@ -1,0 +1,48 @@
+const { RuleTester } = require("eslint");
+const rule = require("./reanimated-default-name.cjs");
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+});
+
+ruleTester.run("reanimated-default-name", rule, {
+  valid: [
+    {
+      code: "import Reanimated from 'react-native-reanimated';\nconst animation = Reanimated.timing();",
+    },
+    {
+      code: "import { something } from 'react-native-reanimated';",
+    },
+    {
+      code: "import Reanimated from 'react-native-reanimated';\nuseAnimatedReaction(() => {}, () => {});",
+    },
+  ],
+
+  invalid: [
+    {
+      code: "import NotReanimated from 'react-native-reanimated';\nconst animation = NotReanimated.timing();",
+      errors: [
+        {
+          message:
+            'Default import from "react-native-reanimated" must be named "Reanimated".',
+        },
+      ],
+      output:
+        "import Reanimated from 'react-native-reanimated';\nconst animation = Reanimated.timing();",
+    },
+    {
+      code: "import NotReanimated from 'react-native-reanimated';\nuseAnimatedReaction(() => {}, () => {});",
+      errors: [
+        {
+          message:
+            'Default import from "react-native-reanimated" must be named "Reanimated".',
+        },
+      ],
+      output:
+        "import Reanimated from 'react-native-reanimated';\nuseAnimatedReaction(() => {}, () => {});",
+    },
+  ],
+});

--- a/projects/eslint-rules/tsconfig.json
+++ b/projects/eslint-rules/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["ESNext"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "../../.moon/cache/types/projects/eslint-rules",
+    "target": "ESNext",
+    "types": ["node"]
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.mts",
+    "**/*.js",
+    "**/*.cjs",
+    "**/*.mjs"
+  ],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1383,13 +1383,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/aix-ppc64@npm:0.25.0"
-  conditions: os=aix & cpu=ppc64
-  languageName: node
-  linkType: hard
-
 "@esbuild/aix-ppc64@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/aix-ppc64@npm:0.25.2"
@@ -1407,13 +1400,6 @@ __metadata:
 "@esbuild/android-arm64@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/android-arm64@npm:0.23.0"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/android-arm64@npm:0.25.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -1439,13 +1425,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/android-arm@npm:0.25.0"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@esbuild/android-arm@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/android-arm@npm:0.25.2"
@@ -1463,13 +1442,6 @@ __metadata:
 "@esbuild/android-x64@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/android-x64@npm:0.23.0"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/android-x64@npm:0.25.0"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -1495,13 +1467,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/darwin-arm64@npm:0.25.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/darwin-arm64@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/darwin-arm64@npm:0.25.2"
@@ -1519,13 +1484,6 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/darwin-x64@npm:0.23.0"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/darwin-x64@npm:0.25.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -1551,13 +1509,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/freebsd-arm64@npm:0.25.0"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/freebsd-arm64@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/freebsd-arm64@npm:0.25.2"
@@ -1575,13 +1526,6 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/freebsd-x64@npm:0.23.0"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/freebsd-x64@npm:0.25.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -1607,13 +1551,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-arm64@npm:0.25.0"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-arm64@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/linux-arm64@npm:0.25.2"
@@ -1631,13 +1568,6 @@ __metadata:
 "@esbuild/linux-arm@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/linux-arm@npm:0.23.0"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-arm@npm:0.25.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -1663,13 +1593,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-ia32@npm:0.25.0"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-ia32@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/linux-ia32@npm:0.25.2"
@@ -1687,13 +1610,6 @@ __metadata:
 "@esbuild/linux-loong64@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/linux-loong64@npm:0.23.0"
-  conditions: os=linux & cpu=loong64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-loong64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-loong64@npm:0.25.0"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -1719,13 +1635,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-mips64el@npm:0.25.0"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-mips64el@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/linux-mips64el@npm:0.25.2"
@@ -1743,13 +1652,6 @@ __metadata:
 "@esbuild/linux-ppc64@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/linux-ppc64@npm:0.23.0"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ppc64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-ppc64@npm:0.25.0"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -1775,13 +1677,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-riscv64@npm:0.25.0"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-riscv64@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/linux-riscv64@npm:0.25.2"
@@ -1799,13 +1694,6 @@ __metadata:
 "@esbuild/linux-s390x@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/linux-s390x@npm:0.23.0"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-s390x@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-s390x@npm:0.25.0"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -1831,24 +1719,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/linux-x64@npm:0.25.0"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-x64@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/linux-x64@npm:0.25.2"
   conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/netbsd-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/netbsd-arm64@npm:0.25.0"
-  conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -1873,13 +1747,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/netbsd-x64@npm:0.25.0"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/netbsd-x64@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/netbsd-x64@npm:0.25.2"
@@ -1890,13 +1757,6 @@ __metadata:
 "@esbuild/openbsd-arm64@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/openbsd-arm64@npm:0.23.0"
-  conditions: os=openbsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/openbsd-arm64@npm:0.25.0"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -1922,13 +1782,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/openbsd-x64@npm:0.25.0"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/openbsd-x64@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/openbsd-x64@npm:0.25.2"
@@ -1946,13 +1799,6 @@ __metadata:
 "@esbuild/sunos-x64@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/sunos-x64@npm:0.23.0"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/sunos-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/sunos-x64@npm:0.25.0"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -1978,13 +1824,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/win32-arm64@npm:0.25.0"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/win32-arm64@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/win32-arm64@npm:0.25.2"
@@ -2006,13 +1845,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/win32-ia32@npm:0.25.0"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@esbuild/win32-ia32@npm:0.25.2":
   version: 0.25.2
   resolution: "@esbuild/win32-ia32@npm:0.25.2"
@@ -2030,13 +1862,6 @@ __metadata:
 "@esbuild/win32-x64@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/win32-x64@npm:0.23.0"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-x64@npm:0.25.0":
-  version: 0.25.0
-  resolution: "@esbuild/win32-x64@npm:0.25.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2093,6 +1918,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/core@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "@eslint/core@npm:0.13.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10c0/ba724a7df7ed9dab387481f11d0d0f708180f40be93acce2c21dacca625c5867de3528760c42f1c457ccefe6a669d525ff87b779017eabc0d33479a36300797b
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^3.3.0, @eslint/eslintrc@npm:^3.3.1":
   version: 3.3.1
   resolution: "@eslint/eslintrc@npm:3.3.1"
@@ -2125,12 +1959,12 @@ __metadata:
   linkType: hard
 
 "@eslint/plugin-kit@npm:^0.2.7":
-  version: 0.2.7
-  resolution: "@eslint/plugin-kit@npm:0.2.7"
+  version: 0.2.8
+  resolution: "@eslint/plugin-kit@npm:0.2.8"
   dependencies:
-    "@eslint/core": "npm:^0.12.0"
+    "@eslint/core": "npm:^0.13.0"
     levn: "npm:^0.4.1"
-  checksum: 10c0/0a1aff1ad63e72aca923217e556c6dfd67d7cd121870eb7686355d7d1475d569773528a8b2111b9176f3d91d2ea81f7413c34600e8e5b73d59e005d70780b633
+  checksum: 10c0/554847c8f2b6bfe0e634f317fc43d0b54771eea0015c4f844f75915fdb9e6170c830c004291bad57db949d61771732e459f36ed059f45cf750af223f77357c5c
   languageName: node
   linkType: hard
 
@@ -2353,7 +2187,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/config@npm:~10.0.10, @expo/config@npm:~10.0.11":
+"@expo/config@npm:~10.0.11":
   version: 10.0.11
   resolution: "@expo/config@npm:10.0.11"
   dependencies:
@@ -2632,6 +2466,7 @@ __metadata:
     "@electric-sql/pglite": "npm:^0.2.15"
     "@eslint/eslintrc": "npm:^3.3.0"
     "@expo/metro-runtime": "npm:~4.0.1"
+    "@haohaohow/eslint-rules": "workspace:*"
     "@haohaohow/lib": "workspace:*"
     "@inkjs/ui": "npm:^2.0.0"
     "@inngest/eslint-plugin": "npm:^0.0.7"
@@ -2772,6 +2607,14 @@ __metadata:
     prettier: "npm:^3.4.2"
     react: "npm:~18.3.1"
     react-email: "npm:^3.0.0"
+  languageName: unknown
+  linkType: soft
+
+"@haohaohow/eslint-rules@workspace:*, @haohaohow/eslint-rules@workspace:projects/eslint-rules":
+  version: 0.0.0-use.local
+  resolution: "@haohaohow/eslint-rules@workspace:projects/eslint-rules"
+  dependencies:
+    eslint: "npm:^9.13.0"
   languageName: unknown
   linkType: soft
 
@@ -4800,25 +4643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-navigation/elements@npm:^2.2.5":
-  version: 2.3.1
-  resolution: "@react-navigation/elements@npm:2.3.1"
-  dependencies:
-    color: "npm:^4.2.3"
-  peerDependencies:
-    "@react-native-masked-view/masked-view": ">= 0.2.0"
-    "@react-navigation/native": ^7.0.19
-    react: ">= 18.2.0"
-    react-native: "*"
-    react-native-safe-area-context: ">= 4.0.0"
-  peerDependenciesMeta:
-    "@react-native-masked-view/masked-view":
-      optional: true
-  checksum: 10c0/249d2d0a25114e697be3e2c133460980cae14717bd6bfc4defe3cf638126c5ede197ef1c9346476246335f6e8df14bbc780aa9d26381bc54d534ddcacf4ac41f
-  languageName: node
-  linkType: hard
-
-"@react-navigation/elements@npm:^2.3.8":
+"@react-navigation/elements@npm:^2.2.5, @react-navigation/elements@npm:^2.3.8":
   version: 2.3.8
   resolution: "@react-navigation/elements@npm:2.3.8"
   dependencies:
@@ -5657,21 +5482,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^22.10.2":
+"@types/node@npm:^22.10.2, @types/node@npm:^22.10.5":
   version: 22.13.17
   resolution: "@types/node@npm:22.13.17"
   dependencies:
     undici-types: "npm:~6.20.0"
   checksum: 10c0/77a052fec0fe02f60557e1c5f3f28eb09cd9bee426be88328a94689150a3c0df5b4b6b69fad28157fb34521693dad0b311ecd7f613845d681ff973991310c20e
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^22.10.5":
-  version: 22.10.7
-  resolution: "@types/node@npm:22.10.7"
-  dependencies:
-    undici-types: "npm:~6.20.0"
-  checksum: 10c0/c941b4689dfc4044b64a5f601306cbcb0c7210be853ba378a5dd44137898c45accedd796ee002ad9407024cac7ecaf5049304951cb1d80ce3d7cebbbae56f20e
   languageName: node
   linkType: hard
 
@@ -7057,17 +6873,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind-apply-helpers@npm:^1.0.0, call-bind-apply-helpers@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "call-bind-apply-helpers@npm:1.0.1"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    function-bind: "npm:^1.1.2"
-  checksum: 10c0/acb2ab68bf2718e68a3e895f0d0b73ccc9e45b9b6f210f163512ba76f91dab409eb8792f6dae188356f9095747512a3101646b3dea9d37fb8c7c6bf37796d18c
-  languageName: node
-  linkType: hard
-
-"call-bind-apply-helpers@npm:^1.0.2":
+"call-bind-apply-helpers@npm:^1.0.0, call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
   version: 1.0.2
   resolution: "call-bind-apply-helpers@npm:1.0.2"
   dependencies:
@@ -7089,17 +6895,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bound@npm:^1.0.2, call-bound@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "call-bound@npm:1.0.3"
-  dependencies:
-    call-bind-apply-helpers: "npm:^1.0.1"
-    get-intrinsic: "npm:^1.2.6"
-  checksum: 10c0/45257b8e7621067304b30dbd638e856cac913d31e8e00a80d6cf172911acd057846572d0b256b45e652d515db6601e2974a1b1a040e91b4fc36fb3dd86fa69cf
-  languageName: node
-  linkType: hard
-
-"call-bound@npm:^1.0.4":
+"call-bound@npm:^1.0.2, call-bound@npm:^1.0.3, call-bound@npm:^1.0.4":
   version: 1.0.4
   resolution: "call-bound@npm:1.0.4"
   dependencies:
@@ -8570,16 +8366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-object-atoms@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "es-object-atoms@npm:1.0.0"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-  checksum: 10c0/1fed3d102eb27ab8d983337bb7c8b159dd2a1e63ff833ec54eea1311c96d5b08223b433060ba240541ca8adba9eee6b0a60cdbf2f80634b784febc9cc8b687b4
-  languageName: node
-  linkType: hard
-
-"es-object-atoms@npm:^1.1.1":
+"es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
   version: 1.1.1
   resolution: "es-object-atoms@npm:1.1.1"
   dependencies:
@@ -8725,7 +8512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.25.2":
+"esbuild@npm:^0.25.2, esbuild@npm:~0.25.0":
   version: 0.25.2
   resolution: "esbuild@npm:0.25.2"
   dependencies:
@@ -8885,92 +8672,6 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10c0/473b1d92842f50a303cf948a11ebd5f69581cd254d599dd9d62f9989858e0533f64e83b723b5e1398a5b488c0f5fd088795b4235f65ecaf4f007d4b79f04bc88
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:~0.25.0":
-  version: 0.25.0
-  resolution: "esbuild@npm:0.25.0"
-  dependencies:
-    "@esbuild/aix-ppc64": "npm:0.25.0"
-    "@esbuild/android-arm": "npm:0.25.0"
-    "@esbuild/android-arm64": "npm:0.25.0"
-    "@esbuild/android-x64": "npm:0.25.0"
-    "@esbuild/darwin-arm64": "npm:0.25.0"
-    "@esbuild/darwin-x64": "npm:0.25.0"
-    "@esbuild/freebsd-arm64": "npm:0.25.0"
-    "@esbuild/freebsd-x64": "npm:0.25.0"
-    "@esbuild/linux-arm": "npm:0.25.0"
-    "@esbuild/linux-arm64": "npm:0.25.0"
-    "@esbuild/linux-ia32": "npm:0.25.0"
-    "@esbuild/linux-loong64": "npm:0.25.0"
-    "@esbuild/linux-mips64el": "npm:0.25.0"
-    "@esbuild/linux-ppc64": "npm:0.25.0"
-    "@esbuild/linux-riscv64": "npm:0.25.0"
-    "@esbuild/linux-s390x": "npm:0.25.0"
-    "@esbuild/linux-x64": "npm:0.25.0"
-    "@esbuild/netbsd-arm64": "npm:0.25.0"
-    "@esbuild/netbsd-x64": "npm:0.25.0"
-    "@esbuild/openbsd-arm64": "npm:0.25.0"
-    "@esbuild/openbsd-x64": "npm:0.25.0"
-    "@esbuild/sunos-x64": "npm:0.25.0"
-    "@esbuild/win32-arm64": "npm:0.25.0"
-    "@esbuild/win32-ia32": "npm:0.25.0"
-    "@esbuild/win32-x64": "npm:0.25.0"
-  dependenciesMeta:
-    "@esbuild/aix-ppc64":
-      optional: true
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/android-arm64":
-      optional: true
-    "@esbuild/android-x64":
-      optional: true
-    "@esbuild/darwin-arm64":
-      optional: true
-    "@esbuild/darwin-x64":
-      optional: true
-    "@esbuild/freebsd-arm64":
-      optional: true
-    "@esbuild/freebsd-x64":
-      optional: true
-    "@esbuild/linux-arm":
-      optional: true
-    "@esbuild/linux-arm64":
-      optional: true
-    "@esbuild/linux-ia32":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    "@esbuild/linux-mips64el":
-      optional: true
-    "@esbuild/linux-ppc64":
-      optional: true
-    "@esbuild/linux-riscv64":
-      optional: true
-    "@esbuild/linux-s390x":
-      optional: true
-    "@esbuild/linux-x64":
-      optional: true
-    "@esbuild/netbsd-arm64":
-      optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-arm64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 10c0/5767b72da46da3cfec51661647ec850ddbf8a8d0662771139f10ef0692a8831396a0004b2be7966cecdb08264fb16bdc16290dcecd92396fac5f12d722fa013d
   languageName: node
   linkType: hard
 
@@ -9625,19 +9326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-manifests@npm:~0.15.7":
-  version: 0.15.7
-  resolution: "expo-manifests@npm:0.15.7"
-  dependencies:
-    "@expo/config": "npm:~10.0.10"
-    expo-json-utils: "npm:~0.14.0"
-  peerDependencies:
-    expo: "*"
-  checksum: 10c0/1116345617fa1383e9de8a8d7593b8da6cbf940f895e76c2402214c240893cb080a1feda400f1910cfd01a045fadc6902a5265c84cdc07f3594ac179da7911d8
-  languageName: node
-  linkType: hard
-
-"expo-manifests@npm:~0.15.8":
+"expo-manifests@npm:~0.15.7, expo-manifests@npm:~0.15.8":
   version: 0.15.8
   resolution: "expo-manifests@npm:0.15.8"
   dependencies:
@@ -10469,25 +10158,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6":
-  version: 1.2.6
-  resolution: "get-intrinsic@npm:1.2.6"
-  dependencies:
-    call-bind-apply-helpers: "npm:^1.0.1"
-    dunder-proto: "npm:^1.0.0"
-    es-define-property: "npm:^1.0.1"
-    es-errors: "npm:^1.3.0"
-    es-object-atoms: "npm:^1.0.0"
-    function-bind: "npm:^1.1.2"
-    gopd: "npm:^1.2.0"
-    has-symbols: "npm:^1.1.0"
-    hasown: "npm:^2.0.2"
-    math-intrinsics: "npm:^1.0.0"
-  checksum: 10c0/0f1ea6d807d97d074e8a31ac698213a12757fcfa9a8f4778263d2e4702c40fe83198aadd3dba2e99aabc2e4cf8a38345545dbb0518297d3df8b00b56a156c32a
-  languageName: node
-  linkType: hard
-
-"get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.3.0":
   version: 1.3.0
   resolution: "get-intrinsic@npm:1.3.0"
   dependencies:
@@ -12756,7 +12427,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"math-intrinsics@npm:^1.0.0, math-intrinsics@npm:^1.1.0":
+"math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
   checksum: 10c0/7579ff94e899e2f76ab64491d76cf606274c874d8f2af4a442c016bd85688927fcfca157ba6bf74b08e9439dc010b248ce05b96cc7c126a354c3bae7fcb48b7f


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a custom ESLint rule to enforce naming of the default import from "react-native-reanimated" as "Reanimated".
  - Added a new ESLint plugin package and integrated it into the app’s linting configuration.

- **Refactor**
  - Updated all references and imports of the animated view component to use "Reanimated" instead of "Animated" throughout the app.

- **Chores**
  - Added configuration and test files for the new ESLint rules package.
  - Updated dependencies to include the new ESLint rules package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->