### PR TITLE
enable @typescript-eslint/consistent-type-imports

### DIFF
--- a/projects/app/bin/generateHanziDecomposition.ts
+++ b/projects/app/bin/generateHanziDecomposition.ts
@@ -3,9 +3,9 @@ import makeDebug from "debug";
 import assert from "node:assert/strict";
 import path from "node:path";
 import yargs from "yargs";
+import type { IdsNode } from "../src/dictionary/dictionary.js";
 import {
   allHanziCharacters,
-  IdsNode,
   loadHanziDecomposition,
   parseIds,
   unicodeShortIdentifier,

--- a/projects/app/bin/generateWordDictionary.tsx
+++ b/projects/app/bin/generateWordDictionary.tsx
@@ -2,16 +2,23 @@
 import hanzi from "hanzi";
 
 import { useInternetQuery, useLocalQuery } from "#client/hooks.ts";
-import { HanziChar, HanziText, HanziWord, PinyinText } from "#data/model.ts";
+import type {
+  HanziChar,
+  HanziText,
+  HanziWord,
+  PinyinText,
+} from "#data/model.ts";
+import type {
+  HanziWordMeaning,
+  HanziWordWithMeaning,
+} from "#dictionary/dictionary.ts";
 import {
   allHanziCharacters,
   allHsk1HanziWords,
   buildHanziWord,
   dictionarySchema,
   hanziFromHanziWord,
-  HanziWordMeaning,
   hanziWordMeaningSchema,
-  HanziWordWithMeaning,
   loadHanziDecomposition,
   lookupHanzi,
   lookupHanziWord,
@@ -41,16 +48,16 @@ import TextInput from "ink-text-input";
 import chunk from "lodash/chunk.js";
 import isEqual from "lodash/isEqual.js";
 import path from "node:path";
+import type { ReactNode } from "react";
 import {
   Children,
   Fragment,
-  ReactNode,
   useCallback,
   useEffect,
   useMemo,
   useState,
 } from "react";
-import { DeepReadonly } from "ts-essentials";
+import type { DeepReadonly } from "ts-essentials";
 import yargs from "yargs";
 import { z } from "zod";
 import { makeDbCache } from "./util/cache.js";

--- a/projects/app/bin/util/cache.ts
+++ b/projects/app/bin/util/cache.ts
@@ -1,4 +1,4 @@
-import { Debugger } from "debug";
+import type { Debugger } from "debug";
 import { DatabaseSync } from "node:sqlite";
 
 export function makeDbCache<K, V>(

--- a/projects/app/bin/util/dongChinese.ts
+++ b/projects/app/bin/util/dongChinese.ts
@@ -1,4 +1,4 @@
-import { PinyinText } from "#data/model.ts";
+import type { PinyinText } from "#data/model.ts";
 import {
   inverseSortComparator,
   memoize0,

--- a/projects/app/bin/util/fetch.ts
+++ b/projects/app/bin/util/fetch.ts
@@ -1,6 +1,6 @@
 import { invariant } from "@haohaohow/lib/invariant";
-import { Debugger } from "debug";
-import { DbCache } from "./cache.js";
+import type { Debugger } from "debug";
+import type { DbCache } from "./cache.js";
 
 export const fetchWithCache = async (
   body: Parameters<typeof fetch>[0],

--- a/projects/app/bin/util/fs.ts
+++ b/projects/app/bin/util/fs.ts
@@ -1,5 +1,5 @@
 import { readFile, stat, writeFile } from "node:fs/promises";
-import { z } from "zod";
+import type { z } from "zod";
 
 export async function writeUtf8FileIfChanged(
   path: string,

--- a/projects/app/bin/util/openai.ts
+++ b/projects/app/bin/util/openai.ts
@@ -1,12 +1,12 @@
 import { invariant } from "@haohaohow/lib/invariant";
-import { Debugger } from "debug";
+import type { Debugger } from "debug";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import OpenAI from "openai";
 import { zodResponseFormat } from "openai/helpers/zod";
-import { ChatCompletionCreateParamsNonStreaming } from "openai/resources/index.mjs";
-import { z } from "zod";
-import { DbCache } from "./cache.js";
+import type { ChatCompletionCreateParamsNonStreaming } from "openai/resources/index.mjs";
+import type { z } from "zod";
+import type { DbCache } from "./cache.js";
 
 export const openAiWithCache = async (
   body: ChatCompletionCreateParamsNonStreaming,

--- a/projects/app/eslint.config.mjs
+++ b/projects/app/eslint.config.mjs
@@ -190,6 +190,7 @@ export default tseslint.config(
       //
       // @typescript-eslint
       //
+      "@typescript-eslint/consistent-type-imports": `error`,
       "@typescript-eslint/no-var-requires": `off`,
       "@typescript-eslint/restrict-template-expressions": [
         `error`,

--- a/projects/app/src/app/(sidenav)/_layout.tsx
+++ b/projects/app/src/app/(sidenav)/_layout.tsx
@@ -2,15 +2,11 @@ import { useAuth } from "@/client/auth";
 import { DevLozenge } from "@/client/ui/DevLozenge";
 import { Image } from "expo-image";
 import { Link } from "expo-router";
-import {
-  TabList,
-  Tabs,
-  TabSlot,
-  TabTrigger,
-  TabTriggerSlotProps,
-} from "expo-router/ui";
+import type { TabTriggerSlotProps } from "expo-router/ui";
+import { TabList, Tabs, TabSlot, TabTrigger } from "expo-router/ui";
 import { StatusBar } from "expo-status-bar";
-import { ElementRef, forwardRef, ReactNode } from "react";
+import type { ElementRef, ReactNode } from "react";
+import { forwardRef } from "react";
 import { Pressable, Text, View } from "react-native";
 import { tv } from "tailwind-variants";
 

--- a/projects/app/src/app/(sidenav)/explore/(radicals)/radicals/[id].tsx
+++ b/projects/app/src/app/(sidenav)/explore/(radicals)/radicals/[id].tsx
@@ -3,7 +3,7 @@ import { ReferencePage } from "@/client/ui/ReferencePage";
 import { ReferencePageBodySection } from "@/client/ui/ReferencePageBodySection";
 import { ReferencePageHeader } from "@/client/ui/ReferencePageHeader";
 import { GradientAqua } from "@/client/ui/styles";
-import { HanziWord } from "@/data/model";
+import type { HanziWord } from "@/data/model";
 import {
   lookupHanziWord,
   lookupHanziWordGlossMnemonics,

--- a/projects/app/src/app/(sidenav)/explore/(radicals)/radicals/new/[id].tsx
+++ b/projects/app/src/app/(sidenav)/explore/(radicals)/radicals/new/[id].tsx
@@ -6,7 +6,7 @@ import { ReferencePage } from "@/client/ui/ReferencePage";
 import { ReferencePageBodySection } from "@/client/ui/ReferencePageBodySection";
 import { ReferencePageHeader } from "@/client/ui/ReferencePageHeader";
 import { GradientAqua, GradientPink } from "@/client/ui/styles";
-import { HanziWord } from "@/data/model";
+import type { HanziWord } from "@/data/model";
 import {
   lookupHanziWord,
   lookupHanziWordGlossMnemonics,

--- a/projects/app/src/app/(sidenav)/learn/_layout.tsx
+++ b/projects/app/src/app/(sidenav)/learn/_layout.tsx
@@ -1,4 +1,4 @@
-import { PropsOf } from "@/client/ui/types";
+import type { PropsOf } from "@/client/ui/types";
 import { Stack } from "expo-router";
 
 export const unstable_settings = {

--- a/projects/app/src/app/(sidenav)/learn/history/index.tsx
+++ b/projects/app/src/app/(sidenav)/learn/history/index.tsx
@@ -1,7 +1,7 @@
 import { targetSkillsReviewQueue } from "@/client/query";
 import { useRizzleQueryPaged } from "@/client/ui/ReplicacheContext";
 import { SkillType } from "@/data/model";
-import {
+import type {
   DeprecatedSkill,
   HanziWordSkill,
   PinyinFinalAssociationSkill,

--- a/projects/app/src/app/(sidenav)/learn/index.tsx
+++ b/projects/app/src/app/(sidenav)/learn/index.tsx
@@ -2,8 +2,9 @@ import { getAllTargetSkills } from "@/client/query";
 import { Countdown } from "@/client/ui/Countdown";
 import { RectButton2 } from "@/client/ui/RectButton2";
 import { useRizzleQueryPaged } from "@/client/ui/ReplicacheContext";
-import { HanziWord, SkillType } from "@/data/model";
-import { HanziWordSkill, Skill } from "@/data/rizzleSchema";
+import type { HanziWord } from "@/data/model";
+import { SkillType } from "@/data/model";
+import type { HanziWordSkill, Skill } from "@/data/rizzleSchema";
 import {
   hanziWordFromSkill,
   skillDueWindow,

--- a/projects/app/src/app/dev/ui.tsx
+++ b/projects/app/src/app/dev/ui.tsx
@@ -2,14 +2,13 @@ import { useQuizProgress } from "@/client/hooks";
 import { HanziText } from "@/client/ui/HanziText";
 import { QuizProgressBar2 } from "@/client/ui/QuizProgressBar2";
 import { RectButton2 } from "@/client/ui/RectButton2";
-import {
-  TextAnswerButton,
-  TextAnswerButtonState,
-} from "@/client/ui/TextAnswerButton";
-import { PropsOf } from "@/client/ui/types";
+import type { TextAnswerButtonState } from "@/client/ui/TextAnswerButton";
+import { TextAnswerButton } from "@/client/ui/TextAnswerButton";
+import type { PropsOf } from "@/client/ui/types";
 import { Link } from "expo-router";
 import shuffle from "lodash/shuffle";
-import { ReactNode, useCallback, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { tv } from "tailwind-variants";

--- a/projects/app/src/client/auth.ts
+++ b/projects/app/src/client/auth.ts
@@ -2,7 +2,7 @@ import { trpc } from "@/client/trpc";
 import { invariant } from "@haohaohow/lib/invariant";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { DeepReadonly } from "ts-essentials";
+import type { DeepReadonly } from "ts-essentials";
 import { z } from "zod";
 import {
   clientStorageGet,

--- a/projects/app/src/client/hooks.ts
+++ b/projects/app/src/client/hooks.ts
@@ -1,10 +1,9 @@
-import { HanziWord } from "@/data/model";
+import type { HanziWord } from "@/data/model";
 import { lookupHanziWord } from "@/dictionary/dictionary";
+import type { UseQueryOptions, UseQueryResult } from "@tanstack/react-query";
 import {
   // eslint-disable-next-line @typescript-eslint/no-restricted-imports
   useQuery,
-  UseQueryOptions,
-  UseQueryResult,
 } from "@tanstack/react-query";
 import * as Haptics from "expo-haptics";
 import {

--- a/projects/app/src/client/query.ts
+++ b/projects/app/src/client/query.ts
@@ -1,18 +1,13 @@
 import { generateQuestionForSkillOrThrow } from "@/data/generator";
-import {
-  Question,
-  QuestionFlag,
-  QuestionFlagType,
-  SrsState,
-  SrsType,
-} from "@/data/model";
-import { Rizzle, Skill } from "@/data/rizzleSchema";
+import type { Question, QuestionFlag, SrsState } from "@/data/model";
+import { QuestionFlagType, SrsType } from "@/data/model";
+import type { Rizzle, Skill } from "@/data/rizzleSchema";
+import type { SkillReviewQueue } from "@/data/skills";
 import {
   hanziWordToGloss,
   hanziWordToPinyin,
   skillDueWindow,
   skillLearningGraph,
-  SkillReviewQueue,
   skillReviewQueue,
 } from "@/data/skills";
 import { allHsk1HanziWords, allHsk2HanziWords } from "@/dictionary/dictionary";

--- a/projects/app/src/client/trpc.tsx
+++ b/projects/app/src/client/trpc.tsx
@@ -1,9 +1,11 @@
 import type { AppRouter } from "@/server/routers/_app";
 import { httpSessionHeader } from "@/util/http";
-import { QueryClient } from "@tanstack/react-query";
-import { HTTPHeaders, httpLink, retryLink } from "@trpc/client";
+import type { QueryClient } from "@tanstack/react-query";
+import type { HTTPHeaders } from "@trpc/client";
+import { httpLink, retryLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
-import { ReactNode, useState } from "react";
+import type { ReactNode } from "react";
+import { useState } from "react";
 
 export const trpc = createTRPCReact<AppRouter>();
 

--- a/projects/app/src/client/ui/CircleButton.tsx
+++ b/projects/app/src/client/ui/CircleButton.tsx
@@ -1,9 +1,11 @@
 import Color from "color";
 import { Image } from "expo-image";
-import { ElementRef, forwardRef, useMemo } from "react";
-import { ColorValue, Pressable, View } from "react-native";
+import type { ElementRef } from "react";
+import { forwardRef, useMemo } from "react";
+import type { ColorValue } from "react-native";
+import { Pressable, View } from "react-native";
 import { hapticImpactIfMobile } from "../hooks";
-import { PropsOf } from "./types";
+import type { PropsOf } from "./types";
 
 export type CircleButtonProps = {
   thickness?: number;

--- a/projects/app/src/client/ui/ErrorBoundary.tsx
+++ b/projects/app/src/client/ui/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/react-native";
 import { Link } from "expo-router";
-import { Text, View, ViewProps } from "react-native";
+import type { ViewProps } from "react-native";
+import { Text, View } from "react-native";
 import { RectButton2 } from "./RectButton2";
 
 export const ErrorBoundary = ({ children }: Pick<ViewProps, `children`>) => {

--- a/projects/app/src/client/ui/HanziWordModal.tsx
+++ b/projects/app/src/client/ui/HanziWordModal.tsx
@@ -1,5 +1,5 @@
 import { useHanziWordMeaning } from "@/client/hooks";
-import { HanziWord } from "@/data/model";
+import type { HanziWord } from "@/data/model";
 import { hanziFromHanziWord, splitHanziText } from "@/dictionary/dictionary";
 import { useMemo } from "react";
 import { ScrollView, Text, View } from "react-native";

--- a/projects/app/src/client/ui/NewSkillModal.tsx
+++ b/projects/app/src/client/ui/NewSkillModal.tsx
@@ -1,6 +1,6 @@
 import { useHanziWordMeaning } from "@/client/hooks";
 import { SkillType } from "@/data/model";
-import { HanziWordSkill, Skill } from "@/data/rizzleSchema";
+import type { HanziWordSkill, Skill } from "@/data/rizzleSchema";
 import { hanziWordFromSkill, skillTypeFromSkill } from "@/data/skills";
 import { hanziFromHanziWord, splitHanziText } from "@/dictionary/dictionary";
 import { Image } from "expo-image";

--- a/projects/app/src/client/ui/PageSheetModal.tsx
+++ b/projects/app/src/client/ui/PageSheetModal.tsx
@@ -1,5 +1,7 @@
-import { ReactNode, useEffect, useMemo, useState } from "react";
-import { Modal, Platform, PressableProps, View } from "react-native";
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
+import type { PressableProps } from "react-native";
+import { Modal, Platform, View } from "react-native";
 import Reanimated, {
   Easing,
   Extrapolation,

--- a/projects/app/src/client/ui/QuizDeck.tsx
+++ b/projects/app/src/client/ui/QuizDeck.tsx
@@ -1,13 +1,12 @@
 import { questionsForReview2 } from "@/client/query";
-import { StackNavigationFor } from "@/client/ui/types";
-import {
+import type { StackNavigationFor } from "@/client/ui/types";
+import type {
   Mistake,
-  MistakeType,
   Question,
   QuestionFlag,
-  QuestionType,
   SkillRating,
 } from "@/data/model";
+import { MistakeType, QuestionType } from "@/data/model";
 import { Rating } from "@/util/fsrs";
 import { nanoid } from "@/util/nanoid";
 import { invariant } from "@haohaohow/lib/invariant";
@@ -16,10 +15,12 @@ import {
   NavigationIndependentTree,
   useTheme,
 } from "@react-navigation/native";
-import {
-  createStackNavigator,
+import type {
   StackCardInterpolatedStyle,
   StackCardInterpolationProps,
+} from "@react-navigation/stack";
+import {
+  createStackNavigator,
   TransitionPresets,
 } from "@react-navigation/stack";
 import { useQueries, useQueryClient } from "@tanstack/react-query";

--- a/projects/app/src/client/ui/QuizDeckMultipleChoiceQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckMultipleChoiceQuestion.tsx
@@ -1,17 +1,15 @@
-import { Mistake, MultipleChoiceQuestion, SkillRating } from "@/data/model";
+import type {
+  Mistake,
+  MultipleChoiceQuestion,
+  SkillRating,
+} from "@/data/model";
 import { setAudioModeAsync, useAudioPlayer } from "expo-audio";
 import chunk from "lodash/chunk";
-import {
-  ElementRef,
-  forwardRef,
-  memo,
-  useCallback,
-  useEffect,
-  useState,
-} from "react";
+import type { ElementRef } from "react";
+import { forwardRef, memo, useCallback, useEffect, useState } from "react";
 import { Text, View } from "react-native";
 import { RectButton } from "./RectButton";
-import { PropsOf } from "./types";
+import type { PropsOf } from "./types";
 
 const buttonThickness = 4;
 const gap = 16;

--- a/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
@@ -1,14 +1,13 @@
 import { useHanziWordMeaning, useMultiChoiceQuizTimer } from "@/client/hooks";
-import {
+import type {
   Mistake,
   OneCorrectPairQuestion,
   OneCorrectPairQuestionChoice,
   QuestionFlag,
-  QuestionFlagType,
   SkillRating,
-  SkillType,
 } from "@/data/model";
-import { HanziWordSkill, Skill } from "@/data/rizzleSchema";
+import { QuestionFlagType, SkillType } from "@/data/model";
+import type { HanziWordSkill, Skill } from "@/data/rizzleSchema";
 import {
   computeSkillRating,
   hanziWordFromSkill,
@@ -20,9 +19,8 @@ import { invariant } from "@haohaohow/lib/invariant";
 import { formatDuration } from "date-fns/formatDuration";
 import { intervalToDuration } from "date-fns/intervalToDuration";
 import { Image } from "expo-image";
+import type { ElementRef, ReactNode } from "react";
 import {
-  ElementRef,
-  ReactNode,
   forwardRef,
   memo,
   useCallback,
@@ -30,16 +28,15 @@ import {
   useMemo,
   useState,
 } from "react";
+import type { StyleProp, ViewStyle } from "react-native";
 import {
   // eslint-disable-next-line @typescript-eslint/no-restricted-imports
   Animated,
   Easing,
   Platform,
   Pressable,
-  StyleProp,
   Text,
   View,
-  ViewStyle,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { tv } from "tailwind-variants";
@@ -49,8 +46,9 @@ import { HanziWordModal } from "./HanziWordModal";
 import { Hhhmark } from "./Hhhmark";
 import { NewSkillModal } from "./NewSkillModal";
 import { RectButton2 } from "./RectButton2";
-import { TextAnswerButton, TextAnswerButtonState } from "./TextAnswerButton";
-import { PropsOf } from "./types";
+import type { TextAnswerButtonState } from "./TextAnswerButton";
+import { TextAnswerButton } from "./TextAnswerButton";
+import type { PropsOf } from "./types";
 
 const buttonThickness = 4;
 const gap = 12;

--- a/projects/app/src/client/ui/QuizProgressBar.tsx
+++ b/projects/app/src/client/ui/QuizProgressBar.tsx
@@ -1,10 +1,10 @@
-import { LinearGradient, LinearGradientProps } from "expo-linear-gradient";
+import type { LinearGradientProps } from "expo-linear-gradient";
+import { LinearGradient } from "expo-linear-gradient";
 import { useEffect, useState } from "react";
+import type { LayoutChangeEvent, LayoutRectangle } from "react-native";
 import {
   // eslint-disable-next-line @typescript-eslint/no-restricted-imports
   Animated,
-  LayoutChangeEvent,
-  LayoutRectangle,
   View,
 } from "react-native";
 import { useEventCallback } from "../hooks";

--- a/projects/app/src/client/ui/QuizProgressBar2.tsx
+++ b/projects/app/src/client/ui/QuizProgressBar2.tsx
@@ -1,10 +1,11 @@
 import { makeRange } from "@/util/collections";
 import { LinearGradient } from "expo-linear-gradient";
 import { useEffect, useMemo, useState } from "react";
-import { LayoutChangeEvent, LayoutRectangle, View } from "react-native";
+import type { LayoutChangeEvent, LayoutRectangle } from "react-native";
+import { View } from "react-native";
+import type { SharedValue } from "react-native-reanimated";
 import Reanimated, {
   Easing,
-  SharedValue,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
@@ -12,7 +13,8 @@ import Reanimated, {
   withTiming,
 } from "react-native-reanimated";
 import { useEventCallback } from "../hooks";
-import { createAffineTransform, Transform1D } from "./animate";
+import type { Transform1D } from "./animate";
+import { createAffineTransform } from "./animate";
 
 const majorTickBgSize = 20;
 const barSize = 16;

--- a/projects/app/src/client/ui/RectButton.tsx
+++ b/projects/app/src/client/ui/RectButton.tsx
@@ -1,8 +1,10 @@
 import Color from "color";
-import { ElementRef, forwardRef, useMemo } from "react";
-import { ColorValue, Pressable, View, ViewProps } from "react-native";
+import type { ElementRef } from "react";
+import { forwardRef, useMemo } from "react";
+import type { ColorValue, ViewProps } from "react-native";
+import { Pressable, View } from "react-native";
 import { hapticImpactIfMobile } from "../hooks";
-import { PropsOf } from "./types";
+import type { PropsOf } from "./types";
 
 export type RectButtonProps = {
   borderRadius?: number;

--- a/projects/app/src/client/ui/RectButton2.tsx
+++ b/projects/app/src/client/ui/RectButton2.tsx
@@ -1,8 +1,10 @@
-import { ElementRef, forwardRef, useState } from "react";
-import { Pressable, Text, View, ViewProps } from "react-native";
+import type { ElementRef } from "react";
+import { forwardRef, useState } from "react";
+import type { ViewProps } from "react-native";
+import { Pressable, Text, View } from "react-native";
 import { tv } from "tailwind-variants";
 import { hapticImpactIfMobile } from "../hooks";
-import { PropsOf } from "./types";
+import type { PropsOf } from "./types";
 
 export type ButtonVariant = `filled` | `outline` | `bare`;
 

--- a/projects/app/src/client/ui/ReferencePage.tsx
+++ b/projects/app/src/client/ui/ReferencePage.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { View } from "react-native";
 
 export const ReferencePage = ({

--- a/projects/app/src/client/ui/ReferencePageHeader.tsx
+++ b/projects/app/src/client/ui/ReferencePageHeader.tsx
@@ -1,4 +1,5 @@
-import { LinearGradient, LinearGradientProps } from "expo-linear-gradient";
+import type { LinearGradientProps } from "expo-linear-gradient";
+import { LinearGradient } from "expo-linear-gradient";
 import { Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CloseButton } from "./CloseButton";

--- a/projects/app/src/client/ui/ReplicacheContext.tsx
+++ b/projects/app/src/client/ui/ReplicacheContext.tsx
@@ -1,21 +1,24 @@
 import { trpc } from "@/client/trpc";
 import { v7Mutators } from "@/data/rizzleMutators";
-import { Rizzle, v7 } from "@/data/rizzleSchema";
-import { AppRouter } from "@/server/routers/_app";
+import type { Rizzle } from "@/data/rizzleSchema";
+import { v7 } from "@/data/rizzleSchema";
+import type { AppRouter } from "@/server/routers/_app";
 import { cookieSchema, r } from "@/util/rizzle";
-import { ReactQueryValue } from "@/util/types";
+import type { ReactQueryValue } from "@/util/types";
 import { invariant } from "@haohaohow/lib/invariant";
 import * as Sentry from "@sentry/core";
-import { QueryKey, useQueryClient } from "@tanstack/react-query";
+import type { QueryKey } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { TRPCClientError } from "@trpc/client";
 import { createContext, useContext, useEffect, useMemo } from "react";
-import {
+import type {
   HTTPRequestInfo,
   PullResponseV1,
   ReadTransaction,
-  TEST_LICENSE_KEY,
 } from "replicache";
-import { useAuth, UseAuth2Data } from "../auth";
+import { TEST_LICENSE_KEY } from "replicache";
+import type { UseAuth2Data } from "../auth";
+import { useAuth } from "../auth";
 import { useLocalQuery, useRenderGuard } from "../hooks";
 import { kvStore } from "./replicacheOptions";
 

--- a/projects/app/src/client/ui/SectionHeaderButton.tsx
+++ b/projects/app/src/client/ui/SectionHeaderButton.tsx
@@ -1,6 +1,6 @@
 import { Text } from "react-native";
 import { RectButton } from "./RectButton";
-import { PropsOf } from "./types";
+import type { PropsOf } from "./types";
 
 export type SectionHeaderButtonProps = {
   title: string;

--- a/projects/app/src/client/ui/ShootingStar.tsx
+++ b/projects/app/src/client/ui/ShootingStar.tsx
@@ -1,6 +1,7 @@
 import LottieView from "lottie-react-native";
 import { useState } from "react";
-import { View, ViewProps } from "react-native";
+import type { ViewProps } from "react-native";
+import { View } from "react-native";
 
 export const ShootingStar = ({ className }: Pick<ViewProps, `className`>) => {
   const [hide, setHide] = useState(false);

--- a/projects/app/src/client/ui/SignInWithAppleButton.web.tsx
+++ b/projects/app/src/client/ui/SignInWithAppleButton.web.tsx
@@ -4,7 +4,7 @@ import { documentEventListenerEffect } from "@/client/hooks";
 import { invariant } from "@haohaohow/lib/invariant";
 import { useEffect, useMemo, useState } from "react";
 import { useEventCallback } from "../hooks";
-import { SignInWithAppleButtonProps } from "./SignInWithAppleButton";
+import type { SignInWithAppleButtonProps } from "./SignInWithAppleButton";
 
 type AppleIdSignInOnSuccessEvent = CustomEvent<AppleSignInAPI.SignInResponseI>;
 type AppleIdSignInOnFailureEvent = CustomEvent<AppleSignInAPI.SignInErrorI>;

--- a/projects/app/src/client/ui/TextAnswerButton.tsx
+++ b/projects/app/src/client/ui/TextAnswerButton.tsx
@@ -1,6 +1,8 @@
 import { characterCount } from "@/dictionary/dictionary";
-import { ElementRef, forwardRef, useEffect, useMemo, useState } from "react";
-import { Pressable, Text, View } from "react-native";
+import type { ElementRef } from "react";
+import { forwardRef, useEffect, useMemo, useState } from "react";
+import type { Pressable } from "react-native";
+import { Text, View } from "react-native";
 import Reanimated, {
   Easing,
   runOnJS,
@@ -16,7 +18,7 @@ import { tv } from "tailwind-variants";
 import { hapticImpactIfMobile } from "../hooks";
 import { AnimatedPressable } from "./AnimatedPressable";
 import { Hhhmark } from "./Hhhmark";
-import { PropsOf } from "./types";
+import type { PropsOf } from "./types";
 
 export type TextAnswerButtonState =
   | `default`

--- a/projects/app/src/client/ui/replicacheOptions.ts
+++ b/projects/app/src/client/ui/replicacheOptions.ts
@@ -1,6 +1,6 @@
 import { ExpoSQLiteKVStore } from "@/util/ExpoSQLiteKVStore";
 import * as SQLite from "expo-sqlite";
-import { ReplicacheOptions } from "replicache";
+import type { ReplicacheOptions } from "replicache";
 
 export const kvStore: ReplicacheOptions<never>[`kvStore`] = {
   create: (name: string) => new ExpoSQLiteKVStore(`replicache-${name}.sqlite`),

--- a/projects/app/src/client/ui/replicacheOptions.web.ts
+++ b/projects/app/src/client/ui/replicacheOptions.web.ts
@@ -1,4 +1,4 @@
-import { ReplicacheOptions } from "replicache";
+import type { ReplicacheOptions } from "replicache";
 
 export const kvStore: ReplicacheOptions<never>[`kvStore`] =
   // For Expo `static` rendering use in-memory KV store (as indexedDB is not

--- a/projects/app/src/client/ui/useSoundEffect.tsx
+++ b/projects/app/src/client/ui/useSoundEffect.tsx
@@ -1,4 +1,5 @@
-import { AudioSource, useAudioPlayer } from "expo-audio";
+import type { AudioSource } from "expo-audio";
+import { useAudioPlayer } from "expo-audio";
 import { useEventCallback, useLocalQuery } from "../hooks";
 
 const audioContext =

--- a/projects/app/src/data/generator.ts
+++ b/projects/app/src/data/generator.ts
@@ -1,15 +1,13 @@
-import {
-  hanziFromHanziWord,
-  HanziWordMeaning,
-  lookupHanziWord,
-} from "@/dictionary/dictionary";
-import { DeepReadonly } from "ts-essentials";
+import type { HanziWordMeaning } from "@/dictionary/dictionary";
+import { hanziFromHanziWord, lookupHanziWord } from "@/dictionary/dictionary";
+import type { DeepReadonly } from "ts-essentials";
 import { hanziWordToGlossQuestionOrThrow } from "./generators/hanziWordToGloss";
 import { hanziWordToPinyinFinalQuestionOrThrow } from "./generators/hanziWordToPinyinFinal";
 import { hanziWordToPinyinInitialQuestionOrThrow } from "./generators/hanziWordToPinyinInitial";
 import { hanziWordToPinyinToneQuestionOrThrow } from "./generators/hanziWordToPinyinTone";
-import { HanziWord, Question, SkillType } from "./model";
-import { HanziWordSkill, Skill } from "./rizzleSchema";
+import type { HanziWord, Question } from "./model";
+import { SkillType } from "./model";
+import type { HanziWordSkill, Skill } from "./rizzleSchema";
 import { skillTypeFromSkill } from "./skills";
 
 export async function generateQuestionForSkillOrThrow(

--- a/projects/app/src/data/generators/hanziWordToGloss.ts
+++ b/projects/app/src/data/generators/hanziWordToGloss.ts
@@ -1,26 +1,25 @@
+import type { HanziWordMeaning } from "@/dictionary/dictionary";
 import {
   allHsk1HanziWords,
   allHsk2HanziWords,
   allHsk3HanziWords,
   glossOrThrow,
   hanziFromHanziWord,
-  HanziWordMeaning,
   lookupHanziWord,
   pinyinOrThrow,
 } from "@/dictionary/dictionary";
 import { evenHalve } from "@/util/collections";
 import { invariant, uniqueInvariant } from "@haohaohow/lib/invariant";
 import shuffle from "lodash/shuffle";
-import { DeepReadonly } from "ts-essentials";
-import {
+import type { DeepReadonly } from "ts-essentials";
+import type {
   HanziWord,
   OneCorrectPairQuestionAnswer,
   OneCorrectPairQuestionChoice,
   Question,
-  QuestionType,
-  SkillType,
 } from "../model";
-import { HanziWordSkill, Skill } from "../rizzleSchema";
+import { QuestionType, SkillType } from "../model";
+import type { HanziWordSkill, Skill } from "../rizzleSchema";
 import { hanziWordFromSkill, skillTypeFromSkill } from "../skills";
 
 // generate a question to test a skill

--- a/projects/app/src/data/generators/hanziWordToPinyinFinal.ts
+++ b/projects/app/src/data/generators/hanziWordToPinyinFinal.ts
@@ -16,16 +16,16 @@ import {
   uniqueInvariant,
 } from "@haohaohow/lib/invariant";
 import shuffle from "lodash/shuffle";
-import {
+import type {
   HanziText,
   HanziWord,
   OneCorrectPairQuestionAnswer,
   OneCorrectPairQuestionChoice,
   PinyinText,
   Question,
-  QuestionType,
 } from "../model";
-import { HanziWordSkill } from "../rizzleSchema";
+import { QuestionType } from "../model";
+import type { HanziWordSkill } from "../rizzleSchema";
 import { hanziOrPinyinWordCount, hanziWordFromSkill } from "../skills";
 
 export async function hanziWordToPinyinFinalQuestionOrThrow(

--- a/projects/app/src/data/generators/hanziWordToPinyinInitial.ts
+++ b/projects/app/src/data/generators/hanziWordToPinyinInitial.ts
@@ -15,16 +15,16 @@ import {
   uniqueInvariant,
 } from "@haohaohow/lib/invariant";
 import shuffle from "lodash/shuffle";
-import {
+import type {
   HanziText,
   HanziWord,
   OneCorrectPairQuestionAnswer,
   OneCorrectPairQuestionChoice,
   PinyinText,
   Question,
-  QuestionType,
 } from "../model";
-import { HanziWordSkill } from "../rizzleSchema";
+import { QuestionType } from "../model";
+import type { HanziWordSkill } from "../rizzleSchema";
 import { hanziOrPinyinWordCount, hanziWordFromSkill } from "../skills";
 
 export async function hanziWordToPinyinInitialQuestionOrThrow(

--- a/projects/app/src/data/generators/hanziWordToPinyinTone.ts
+++ b/projects/app/src/data/generators/hanziWordToPinyinTone.ts
@@ -15,16 +15,16 @@ import {
   uniqueInvariant,
 } from "@haohaohow/lib/invariant";
 import shuffle from "lodash/shuffle";
-import {
+import type {
   HanziText,
   HanziWord,
   OneCorrectPairQuestionAnswer,
   OneCorrectPairQuestionChoice,
   PinyinText,
   Question,
-  QuestionType,
 } from "../model";
-import { HanziWordSkill } from "../rizzleSchema";
+import { QuestionType } from "../model";
+import type { HanziWordSkill } from "../rizzleSchema";
 import { hanziOrPinyinWordCount, hanziWordFromSkill } from "../skills";
 
 export async function hanziWordToPinyinToneQuestionOrThrow(

--- a/projects/app/src/data/model.ts
+++ b/projects/app/src/data/model.ts
@@ -1,7 +1,7 @@
-import { Rating } from "@/util/fsrs";
+import type { Rating } from "@/util/fsrs";
 import type { Interval } from "date-fns";
-import { z } from "zod";
-import { Skill } from "./rizzleSchema";
+import type { z } from "zod";
+import type { Skill } from "./rizzleSchema";
 
 export enum PinyinInitialGroupId {
   Basic,

--- a/projects/app/src/data/rizzleMutators.ts
+++ b/projects/app/src/data/rizzleMutators.ts
@@ -1,10 +1,12 @@
 import { loadDictionary } from "@/dictionary/dictionary";
 import { sortComparatorDate } from "@/util/collections";
-import { FsrsState, nextReview } from "@/util/fsrs";
-import { RizzleReplicacheMutators } from "@/util/rizzle";
+import type { FsrsState } from "@/util/fsrs";
+import { nextReview } from "@/util/fsrs";
+import type { RizzleReplicacheMutators } from "@/util/rizzle";
 import { invariant } from "@haohaohow/lib/invariant";
 import { MistakeType } from "./model";
-import { srsStateFromFsrsState, v7 } from "./rizzleSchema";
+import type { v7 } from "./rizzleSchema";
+import { srsStateFromFsrsState } from "./rizzleSchema";
 import {
   nextReviewForOtherSkillMistake,
   skillsToReReviewForHanziGlossMistake,

--- a/projects/app/src/data/rizzleSchema.ts
+++ b/projects/app/src/data/rizzleSchema.ts
@@ -1,15 +1,15 @@
 import { memoize0 } from "@/util/collections";
-import { FsrsState, Rating } from "@/util/fsrs";
-import { r, RizzleCustom, RizzleReplicache } from "@/util/rizzle";
+import type { FsrsState } from "@/util/fsrs";
+import { Rating } from "@/util/fsrs";
+import type { RizzleReplicache } from "@/util/rizzle";
+import { r, RizzleCustom } from "@/util/rizzle";
 import { z } from "zod";
+import type { HanziText, PinyinText, SrsState } from "./model";
 import {
-  HanziText,
   MnemonicThemeId,
   PartOfSpeech,
   PinyinInitialGroupId,
-  PinyinText,
   SkillType,
-  SrsState,
   SrsType,
 } from "./model";
 

--- a/projects/app/src/data/skills.ts
+++ b/projects/app/src/data/skills.ts
@@ -1,9 +1,9 @@
+import type { HanziWordWithMeaning } from "@/dictionary/dictionary";
 import {
   characterCount,
   characterHasGlyph,
   decomposeHanzi,
   hanziFromHanziWord,
-  HanziWordWithMeaning,
   isHanziChar,
   lookupGloss,
   lookupHanzi,
@@ -17,28 +17,25 @@ import { makePRNG } from "@/util/random";
 import { invariant } from "@haohaohow/lib/invariant";
 import type { Duration } from "date-fns";
 import { subDays } from "date-fns/subDays";
-import { DeepReadonly } from "ts-essentials";
-import {
+import type { DeepReadonly } from "ts-essentials";
+import type {
   HanziGlossMistake,
   HanziPinyinMistake,
   HanziWord,
   HanziWordSkillType,
   Mistake,
-  MistakeType,
   OneCorrectPairQuestionChoice,
   SkillRating,
-  SkillType,
   SrsState,
-  SrsType,
 } from "./model";
-import {
+import { MistakeType, SkillType, SrsType } from "./model";
+import type {
   HanziWordSkill,
   PinyinFinalAssociationSkill,
   PinyinInitialAssociationSkill,
-  rSkillType,
   Skill,
-  srsStateFromFsrsState,
 } from "./rizzleSchema";
+import { rSkillType, srsStateFromFsrsState } from "./rizzleSchema";
 
 export interface Node {
   skill: Skill;

--- a/projects/app/src/dictionary/dictionary.ts
+++ b/projects/app/src/dictionary/dictionary.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   HanziChar,
   HanziText,
   HanziWord,
-  PartOfSpeech,
   PinyinInitialGroupId,
   PinyinText,
 } from "@/data/model";
+import { PartOfSpeech } from "@/data/model";
 import { rMnemonicThemeId, rPinyinInitialGroupId } from "@/data/rizzleSchema";
 import {
   deepReadonly,
@@ -16,7 +16,7 @@ import {
   sortComparatorNumber,
 } from "@/util/collections";
 import { invariant } from "@haohaohow/lib/invariant";
-import { DeepReadonly, StrictExtract } from "ts-essentials";
+import type { DeepReadonly, StrictExtract } from "ts-essentials";
 import { z } from "zod";
 
 export const hanziWordSchema = z.string().transform((x) => x as HanziWord);

--- a/projects/app/src/server/lib/auth.ts
+++ b/projects/app/src/server/lib/auth.ts
@@ -3,7 +3,7 @@ import { DrizzlePostgreSQLAdapter } from "@lucia-auth/adapter-drizzle";
 import { and, eq } from "drizzle-orm";
 import { Lucia, TimeSpan } from "lucia";
 import * as schema from "../schema";
-import { Drizzle } from "./db";
+import type { Drizzle } from "./db";
 
 export function getLucia(db: Drizzle) {
   const adapter = new DrizzlePostgreSQLAdapter(

--- a/projects/app/src/server/lib/db.ts
+++ b/projects/app/src/server/lib/db.ts
@@ -1,8 +1,14 @@
 import { invariant } from "@haohaohow/lib/invariant";
-import { GetColumnData, sql, SQL, SQLWrapper } from "drizzle-orm";
-import { drizzle, NodePgDatabase } from "drizzle-orm/node-postgres";
-import type { PgColumn, PgTable } from "drizzle-orm/pg-core";
-import { AnyPgTable, PgTransactionConfig } from "drizzle-orm/pg-core";
+import type { GetColumnData, SQL, SQLWrapper } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { drizzle } from "drizzle-orm/node-postgres";
+import type {
+  PgColumn,
+  PgTable,
+  AnyPgTable,
+  PgTransactionConfig,
+} from "drizzle-orm/pg-core";
 import type { Pool as PgPool } from "pg";
 import z from "zod";
 import * as schema from "../schema";

--- a/projects/app/src/server/lib/inngest.ts
+++ b/projects/app/src/server/lib/inngest.ts
@@ -5,7 +5,7 @@ import {
   loadDictionary,
   loadHanziWordMigrations,
 } from "@/dictionary/dictionary";
-import { AppRouter } from "@/server/routers/_app";
+import type { AppRouter } from "@/server/routers/_app";
 import { preflightCheckEnvVars } from "@/util/env";
 import { httpSessionHeader } from "@/util/http";
 import { invariant } from "@haohaohow/lib/invariant";

--- a/projects/app/src/server/lib/queries.ts
+++ b/projects/app/src/server/lib/queries.ts
@@ -1,10 +1,12 @@
-import { SrsState, SrsType } from "@/data/model";
-import { Skill } from "@/data/rizzleSchema";
-import { FsrsState, nextReview } from "@/util/fsrs";
+import type { SrsState } from "@/data/model";
+import { SrsType } from "@/data/model";
+import type { Skill } from "@/data/rizzleSchema";
+import type { FsrsState } from "@/util/fsrs";
+import { nextReview } from "@/util/fsrs";
 import { invariant } from "@haohaohow/lib/invariant";
 import { and, asc, eq } from "drizzle-orm";
 import * as schema from "../schema";
-import { Drizzle } from "./db";
+import type { Drizzle } from "./db";
 
 export async function updateSkillState(
   tx: Drizzle,

--- a/projects/app/src/server/lib/replicache.ts
+++ b/projects/app/src/server/lib/replicache.ts
@@ -1,29 +1,27 @@
 import { MistakeType } from "@/data/model";
-import {
-  rPinyinInitialGroupId,
-  SupportedSchema,
-  v7,
-  v7_1,
-} from "@/data/rizzleSchema";
+import type { SupportedSchema } from "@/data/rizzleSchema";
+import { rPinyinInitialGroupId, v7, v7_1 } from "@/data/rizzleSchema";
 import {
   nextReviewForOtherSkillMistake,
   skillsToReReviewForHanziGlossMistake,
   skillsToReReviewForHanziPinyinMistake,
 } from "@/data/skills";
-import {
+import type {
   ClientStateNotFoundResponse,
   Cookie,
-  makeDrizzleMutationHandler,
   MutateHandler,
   PullOkResponse,
   PullRequest,
   PushRequest,
-  pushRequestSchema,
   PushResponse,
   ReplicacheMutation,
-  replicacheMutationSchema,
   RizzleDrizzleMutators,
   VersionNotSupportedResponse,
+} from "@/util/rizzle";
+import {
+  makeDrizzleMutationHandler,
+  pushRequestSchema,
+  replicacheMutationSchema,
 } from "@/util/rizzle";
 import { invariant } from "@haohaohow/lib/invariant";
 import { startSpan } from "@sentry/core";
@@ -32,7 +30,7 @@ import { and, eq, gt, inArray, sql } from "drizzle-orm";
 import chunk from "lodash/chunk";
 import mapValues from "lodash/mapValues";
 import pickBy from "lodash/pickBy";
-import { z } from "zod";
+import type { z } from "zod";
 import * as s from "../schema";
 import type { Drizzle } from "./db";
 import {

--- a/projects/app/src/server/lib/trpc.ts
+++ b/projects/app/src/server/lib/trpc.ts
@@ -1,6 +1,6 @@
 import { trpcMiddleware } from "@sentry/core";
 import { initTRPC, TRPCError } from "@trpc/server";
-import { Context } from "./trpcContext";
+import type { Context } from "./trpcContext";
 
 // Avoid exporting the entire t-object since it's not very descriptive. For
 // instance, the use of a t variable is common in i18n libraries.

--- a/projects/app/src/server/lib/trpcContext.ts
+++ b/projects/app/src/server/lib/trpcContext.ts
@@ -1,6 +1,6 @@
 import { httpSessionHeader } from "@/util/http";
 import { TRPCError } from "@trpc/server";
-import { FetchCreateContextFnOptions } from "@trpc/server/adapters/fetch";
+import type { FetchCreateContextFnOptions } from "@trpc/server/adapters/fetch";
 import { withDrizzle } from "./db";
 
 export async function createContext({ req }: FetchCreateContextFnOptions) {

--- a/projects/app/src/server/schemaUtil.ts
+++ b/projects/app/src/server/schemaUtil.ts
@@ -1,11 +1,12 @@
 import * as r from "@/data/rizzleSchema";
 import { isRunningTests } from "@/util/env";
-import { RizzleType, RizzleTypeDef } from "@/util/rizzle";
+import type { RizzleType, RizzleTypeDef } from "@/util/rizzle";
 import { invariant } from "@haohaohow/lib/invariant";
-import { ColumnBaseConfig, Table } from "drizzle-orm";
-import * as s from "drizzle-orm/pg-core";
+import type { ColumnBaseConfig } from "drizzle-orm";
+import { Table } from "drizzle-orm";
+import type * as s from "drizzle-orm/pg-core";
 import { customType } from "drizzle-orm/pg-core";
-import { z, ZodError } from "zod";
+import type { z, ZodError } from "zod";
 
 type PgCustomColumn = s.PgCustomColumn<
   ColumnBaseConfig<`custom`, `PgCustomColumn`>

--- a/projects/app/src/types/node.d.ts
+++ b/projects/app/src/types/node.d.ts
@@ -1,9 +1,11 @@
+import type { AudioSource } from "expo-audio";
+
 declare global {
   interface NodeRequire {
     // Support for asset files. Anything that starts with a dot and ends with a
     // known extension.
     (id: `${string}.${`ttf` | `otf` | `svg` | `png` | `json`}`): string;
-    (id: `${string}.mp3`): import("expo-audio").AudioSource;
+    (id: `${string}.mp3`): AudioSource;
   }
 
   namespace NodeJS {

--- a/projects/app/src/util/rizzle.ts
+++ b/projects/app/src/util/rizzle.ts
@@ -9,18 +9,18 @@ import fromAsync from "array-from-async";
 import mapKeys from "lodash/mapKeys";
 import mapValues from "lodash/mapValues";
 import memoize from "lodash/memoize";
-import {
+import type {
   IndexDefinition,
   MutatorDefs,
   ReadonlyJSONValue,
   ReadTransaction,
-  Replicache,
   ReplicacheOptions,
   WriteTransaction,
 } from "replicache";
-import { AnyFunction } from "ts-essentials";
+import { Replicache } from "replicache";
+import type { AnyFunction } from "ts-essentials";
 import { z } from "zod";
-import { PartialIfUndefined } from "./types";
+import type { PartialIfUndefined } from "./types";
 
 export interface RizzleTypeDef {
   description?: string;

--- a/projects/app/test/app/api/helpers.ts
+++ b/projects/app/test/app/api/helpers.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn as _spawn } from "node:child_process";
-import { TestContext } from "node:test";
+import type { TestContext } from "node:test";
 import { setTimeout } from "node:timers/promises";
 
 export type TestExpoServer = Awaited<ReturnType<typeof testExpoServer>>;

--- a/projects/app/test/client/query.test.ts
+++ b/projects/app/test/client/query.test.ts
@@ -3,15 +3,12 @@ import {
   flagsForSrsState,
   targetSkillsReviewQueue,
 } from "#client/query.ts";
-import {
-  HanziText,
-  PinyinText,
-  QuestionFlagType,
-  SrsType,
-} from "#data/model.ts";
+import type { HanziText, PinyinText } from "#data/model.ts";
+import { QuestionFlagType, SrsType } from "#data/model.ts";
 import { v7Mutators } from "#data/rizzleMutators.ts";
-import { Skill, v7 } from "#data/rizzleSchema.ts";
-import { SkillReviewQueue } from "#data/skills.ts";
+import type { Skill } from "#data/rizzleSchema.ts";
+import { v7 } from "#data/rizzleSchema.ts";
+import type { SkillReviewQueue } from "#data/skills.ts";
 import { Rating } from "#util/fsrs.ts";
 import { nanoid } from "#util/nanoid.ts";
 import { r } from "#util/rizzle.ts";

--- a/projects/app/test/data/helpers.ts
+++ b/projects/app/test/data/helpers.ts
@@ -1,12 +1,10 @@
-import {
-  SrsStateFsrsFourPointFive,
-  SrsStateMock,
-  SrsType,
-} from "#data/model.ts";
-import { nextReview, Rating } from "#util/fsrs.ts";
+import type { SrsStateFsrsFourPointFive, SrsStateMock } from "#data/model.ts";
+import { SrsType } from "#data/model.ts";
+import type { Rating } from "#util/fsrs.ts";
+import { nextReview } from "#util/fsrs.ts";
 import { invariant } from "@haohaohow/lib/invariant";
-import { TestContext } from "node:test";
-import { ReadTransaction, WriteTransaction } from "replicache";
+import type { TestContext } from "node:test";
+import type { ReadTransaction, WriteTransaction } from "replicache";
 
 export function makeMockTx(t: TestContext) {
   const readTx = {

--- a/projects/app/test/data/rizzleSchema.test.ts
+++ b/projects/app/test/data/rizzleSchema.test.ts
@@ -3,8 +3,9 @@ import { rSkill, rSkillType } from "#data/rizzleSchema.ts";
 import { hanziWordToGloss } from "#data/skills.ts";
 import { r } from "#util/rizzle.ts";
 import assert from "node:assert/strict";
-import test, { TestContext } from "node:test";
-import { ReadTransaction, WriteTransaction } from "replicache";
+import type { TestContext } from "node:test";
+import test from "node:test";
+import type { ReadTransaction, WriteTransaction } from "replicache";
 
 function makeMockTx(t: TestContext) {
   const readTx = {

--- a/projects/app/test/data/skills.test.ts
+++ b/projects/app/test/data/skills.test.ts
@@ -1,9 +1,9 @@
 import { SkillType } from "#data/model.ts";
-import { Skill } from "#data/rizzleSchema.ts";
+import type { Skill } from "#data/rizzleSchema.ts";
+import type { SkillLearningGraph } from "#data/skills.ts";
 import {
   computeSkillRating,
   hanziWordToGloss,
-  SkillLearningGraph,
   skillLearningGraph,
   skillReviewQueue,
   skillTypeFromSkill,

--- a/projects/app/test/dictionary/dictionary.test.ts
+++ b/projects/app/test/dictionary/dictionary.test.ts
@@ -1,4 +1,5 @@
-import { HanziChar } from "#data/model.ts";
+import type { HanziChar } from "#data/model.ts";
+import type { HanziWordMeaning, PinyinChart } from "#dictionary/dictionary.ts";
 import {
   allHanziCharacters,
   allHanziWordsHanzi,
@@ -11,7 +12,6 @@ import {
   decomposeHanzi,
   flattenIds,
   hanziFromHanziWord,
-  HanziWordMeaning,
   hanziWordMeaningSchema,
   idsNodeToString,
   IdsOperator,
@@ -33,7 +33,6 @@ import {
   meaningKeyFromHanziWord,
   parseIds,
   parsePinyinTone,
-  PinyinChart,
   splitHanziText,
   splitTonelessPinyin,
   unicodeShortIdentifier,
@@ -49,8 +48,8 @@ import { invariant, uniqueInvariant } from "@haohaohow/lib/invariant";
 import assert from "node:assert/strict";
 import test from "node:test";
 import { zodResponseFormat } from "openai/helpers/zod";
-import { DeepReadonly } from "ts-essentials";
-import { z } from "zod";
+import type { DeepReadonly } from "ts-essentials";
+import type { z } from "zod";
 
 await test(`radical groups have the right number of elements`, async () => {
   // Data integrity test to ensure that the number of characters in each group

--- a/projects/app/test/server/lib/db.test.ts
+++ b/projects/app/test/server/lib/db.test.ts
@@ -1,13 +1,16 @@
-import { Skill, srsStateFromFsrsState } from "#data/rizzleSchema.ts";
+import type { Skill } from "#data/rizzleSchema.ts";
+import { srsStateFromFsrsState } from "#data/rizzleSchema.ts";
 import { glossToHanziWord } from "#data/skills.ts";
-import { Drizzle, pgBatchUpdate, substring } from "#server/lib/db.ts";
+import type { Drizzle } from "#server/lib/db.ts";
+import { pgBatchUpdate, substring } from "#server/lib/db.ts";
 import * as s from "#server/schema.ts";
 import { nextReview, Rating } from "#util/fsrs.ts";
 import { invariant } from "@haohaohow/lib/invariant";
 import { eq } from "drizzle-orm";
 import * as pg from "drizzle-orm/pg-core";
 import assert from "node:assert/strict";
-import test, { TestContext } from "node:test";
+import type { TestContext } from "node:test";
+import test from "node:test";
 import { createUser, withDbTest, withTxTest } from "./dbHelpers";
 
 function typeChecks(..._args: unknown[]) {

--- a/projects/app/test/server/lib/dbHelpers.ts
+++ b/projects/app/test/server/lib/dbHelpers.ts
@@ -1,12 +1,12 @@
-import { Drizzle, Transaction } from "#server/lib/db.ts";
+import type { Drizzle, Transaction } from "#server/lib/db.ts";
 import * as s from "#server/schema.ts";
 import { nanoid } from "#util/nanoid.ts";
 import { PGlite } from "@electric-sql/pglite";
-import { PgTransactionConfig } from "drizzle-orm/pg-core";
+import type { PgTransactionConfig } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/pglite";
 import { migrate } from "drizzle-orm/pglite/migrator";
 import assert from "node:assert/strict";
-import { TestContext } from "node:test";
+import type { TestContext } from "node:test";
 
 const migrationsFolder = import.meta.dirname + `/../../../drizzle`;
 

--- a/projects/app/test/types.d.ts
+++ b/projects/app/test/types.d.ts
@@ -1,8 +1,10 @@
-import { JestNativeMatchers } from "@testing-library/react-native/build/matchers/types";
+import type { JestNativeMatchers } from "@testing-library/react-native/build/matchers/types";
 
 declare global {
+  import type { Expect } from "expect";
+
   // This is needed so that in `setup.ts` we can do `globalThis.expect = …`.
-  var expect: typeof import("expect").expect;
+  var expect: Expect;
 }
 
 declare module "expect" {

--- a/projects/app/test/util/fsrs.test.ts
+++ b/projects/app/test/util/fsrs.test.ts
@@ -1,17 +1,18 @@
+import type { FsrsState } from "#util/fsrs.ts";
 import {
-  FsrsState,
   Rating,
   fsrsIsForgotten,
   fsrsPredictedRecallProbability,
   nextReview,
   ratingName,
 } from "#util/fsrs.ts";
-import { RepeatedSequence2 } from "#util/types.ts";
+import type { RepeatedSequence2 } from "#util/types.ts";
 import type { Duration } from "date-fns";
 import { add } from "date-fns/add";
 import { intervalToDuration } from "date-fns/intervalToDuration";
 import assert from "node:assert/strict";
-import test, { TestContext } from "node:test";
+import type { TestContext } from "node:test";
+import test from "node:test";
 import z from "zod";
 import { parseRelativeTimeShorthand } from "../data/helpers";
 

--- a/projects/app/test/util/rizzle.test.ts
+++ b/projects/app/test/util/rizzle.test.ts
@@ -1,8 +1,6 @@
 import { nanoid } from "#util/nanoid.ts";
-import {
+import type {
   ExtractVariableNames,
-  keyPathVariableNames,
-  r,
   RizzleCustom,
   RizzleIndexed,
   RizzleIndexTypes,
@@ -15,12 +13,15 @@ import {
   RizzleReplicacheMutators,
   RizzleReplicacheQuery,
 } from "#util/rizzle.ts";
-import { IsEqual } from "#util/types.ts";
+import { keyPathVariableNames, r } from "#util/rizzle.ts";
+import type { IsEqual } from "#util/types.ts";
 import mapValues from "lodash/mapValues";
 import shuffle from "lodash/shuffle";
 import assert from "node:assert/strict";
-import test, { TestContext } from "node:test";
-import { ReadTransaction, Replicache, WriteTransaction } from "replicache";
+import type { TestContext } from "node:test";
+import test from "node:test";
+import type { ReadTransaction, WriteTransaction } from "replicache";
+import { Replicache } from "replicache";
 import { z } from "zod";
 import { testReplicacheOptions } from "./rizzleHelpers";
 

--- a/projects/app/test/util/rizzleHelpers.ts
+++ b/projects/app/test/util/rizzleHelpers.ts
@@ -1,4 +1,5 @@
-import { ReplicacheOptions, TEST_LICENSE_KEY } from "replicache";
+import type { ReplicacheOptions } from "replicache";
+import { TEST_LICENSE_KEY } from "replicache";
 
 let _testReplicacheNameId = 0;
 /**

--- a/projects/app/test/util/types.test.ts
+++ b/projects/app/test/util/types.test.ts
@@ -1,4 +1,4 @@
-import { Flatten, IsEqual, PartialIfUndefined } from "#util/types.ts";
+import type { Flatten, IsEqual, PartialIfUndefined } from "#util/types.ts";
 import assert from "node:assert/strict";
 import test from "node:test";
 


### PR DESCRIPTION
force all type imports to use `import type` for easier syntax erasure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated import statements throughout the codebase to use TypeScript’s type-only import syntax where appropriate. This clarifies the distinction between types and runtime values, improves code clarity, and may reduce bundle size.
  - Adjusted import organization and ordering for better maintainability and readability.
  - Enforced consistent type import usage in TypeScript files via updated linting rules.

- **Style**
  - No changes to application behavior, features, or user interface.

- **Documentation**
  - No user-facing documentation changes.

- **Chores**
  - Minor updates to type declarations for improved type safety in global and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->