### PR TITLE
retry incorrect answers immediately

### DIFF
--- a/projects/app/src/app/(sidenav)/learn/history/index.tsx
+++ b/projects/app/src/app/(sidenav)/learn/history/index.tsx
@@ -1,21 +1,7 @@
 import { targetSkillsReviewQueue } from "@/client/query";
 import { useRizzleQueryPaged } from "@/client/ui/ReplicacheContext";
-import { HanziWordRefText } from "@/client/ui/WikiHanziWordModal";
-import { SkillType } from "@/data/model";
-import type {
-  DeprecatedSkill,
-  HanziWordSkill,
-  PinyinFinalAssociationSkill,
-  PinyinInitialAssociationSkill,
-  Skill,
-} from "@/data/rizzleSchema";
-import {
-  finalFromPinyinFinalAssociationSkill,
-  hanziWordFromSkill,
-  initialFromPinyinInitialAssociationSkill,
-  skillTypeFromSkill,
-  skillTypeToShorthand,
-} from "@/data/skills";
+import { SkillRefText } from "@/client/ui/SkillRefText";
+import { skillTypeFromSkill, skillTypeToShorthand } from "@/data/skills";
 import {
   emptyArray,
   inverseSortComparator,
@@ -75,9 +61,7 @@ export default function HistoryPage() {
 
             {data2Query.data?.available.slice(0, 100).map((skill, i) => (
               <View key={i} className="flex-col items-center">
-                <Text className="hhh-text-body">
-                  <InlineSkillRef skill={skill} />
-                </Text>
+                <SkillRefText skill={skill} context="body" />
                 <Text className="hhh-text-caption">
                   {skillTypeToShorthand(skillTypeFromSkill(skill))}
                 </Text>
@@ -104,7 +88,7 @@ export default function HistoryPage() {
                 const { skill, createdAt } = value;
                 return (
                   <View key={i}>
-                    <Text className="text-text">
+                    <Text className="hhh-text-body">
                       {value.rating === Rating.Again
                         ? `❌`
                         : value.rating === Rating.Hard
@@ -116,7 +100,7 @@ export default function HistoryPage() {
                               ? `🟢`
                               : value.rating}
                       {` `}
-                      <InlineSkillRef skill={skill} />:{` `}
+                      <SkillRefText skill={skill} context="body" />:{` `}
                       {createdAt.toISOString()}
                     </Text>
                   </View>
@@ -129,36 +113,3 @@ export default function HistoryPage() {
     </ScrollView>
   );
 }
-
-const InlineSkillRef = ({ skill }: { skill: Skill }) => {
-  switch (skillTypeFromSkill(skill)) {
-    case SkillType.PinyinFinalAssociation: {
-      skill = skill as PinyinFinalAssociationSkill;
-      return <Text>-{finalFromPinyinFinalAssociationSkill(skill)}</Text>;
-    }
-    case SkillType.PinyinInitialAssociation: {
-      skill = skill as PinyinInitialAssociationSkill;
-      return <Text>{initialFromPinyinInitialAssociationSkill(skill)}-</Text>;
-    }
-    case SkillType.Deprecated_RadicalToEnglish:
-    case SkillType.Deprecated_EnglishToRadical:
-    case SkillType.Deprecated_RadicalToPinyin:
-    case SkillType.Deprecated_PinyinToRadical:
-    case SkillType.Deprecated: {
-      skill = skill as DeprecatedSkill;
-      return <Text>{skillTypeToShorthand(skillTypeFromSkill(skill))}</Text>;
-    }
-    case SkillType.HanziWordToGloss:
-    case SkillType.HanziWordToPinyin:
-    case SkillType.HanziWordToPinyinInitial:
-    case SkillType.HanziWordToPinyinFinal:
-    case SkillType.HanziWordToPinyinTone:
-    case SkillType.GlossToHanziWord:
-    case SkillType.PinyinToHanziWord:
-    case SkillType.ImageToHanziWord: {
-      skill = skill as HanziWordSkill;
-      const hanziWord = hanziWordFromSkill(skill);
-      return <HanziWordRefText hanziWord={hanziWord} />;
-    }
-  }
-};

--- a/projects/app/src/client/query.ts
+++ b/projects/app/src/client/query.ts
@@ -1,7 +1,7 @@
 import { generateQuestionForSkillOrThrow } from "@/data/generator";
 import type { Question, QuestionFlag, SrsState } from "@/data/model";
 import { QuestionFlagType, SrsType } from "@/data/model";
-import type { Rizzle, Skill } from "@/data/rizzleSchema";
+import type { Rizzle, Skill, SkillRating } from "@/data/rizzleSchema";
 import type { SkillReviewQueue } from "@/data/skills";
 import {
   hanziWordToGloss,
@@ -106,5 +106,16 @@ export async function computeSkillReviewQueue(
     skillSrsStates.set(v.skill, v.srs);
   }
 
-  return skillReviewQueue({ graph, skillSrsStates, now });
+  const latestSkillRatings = new Map<Skill, SkillRating>();
+  // const res = await r.queryPaged.skillRating.byCreatedAt().toArray();
+  for await (const [, v] of r.queryPaged.skillRating.byCreatedAt()) {
+    latestSkillRatings.set(v.skill, v);
+  }
+
+  return skillReviewQueue({
+    graph,
+    skillSrsStates,
+    latestSkillRatings,
+    now,
+  });
 }

--- a/projects/app/src/client/ui/GlossHint.tsx
+++ b/projects/app/src/client/ui/GlossHint.tsx
@@ -22,12 +22,12 @@ export const GlossHint = ({
     <View className="gap-1">
       {parts.headline == null ? null : (
         <Text className={headlineClassName}>
-          <Hhhmark source={parts.headline} />
+          <Hhhmark source={parts.headline} context="body" />
         </Text>
       )}
       {parts.explanation == null || hideExplanation ? null : (
         <Text className={explanationClassName}>
-          <Hhhmark source={parts.explanation} />
+          <Hhhmark source={parts.explanation} context="body" />
         </Text>
       )}
     </View>

--- a/projects/app/src/client/ui/HanziWordRefText.tsx
+++ b/projects/app/src/client/ui/HanziWordRefText.tsx
@@ -1,0 +1,45 @@
+import { useHanziWordMeaning } from "@/client/hooks/useHanziWordMeaning";
+import type { HanziWord } from "@/data/model";
+import { glossOrThrow, hanziFromHanziWord } from "@/dictionary/dictionary";
+import { lazy, useState } from "react";
+import { Text } from "react-native";
+
+const WikiHanziWordModal = lazy(() => import(`./WikiHanziWordModal`));
+
+export const HanziWordRefText = ({
+  hanziWord,
+  context,
+}: {
+  hanziWord: HanziWord;
+  context: `body` | `caption`;
+}) => {
+  const meaning = useHanziWordMeaning(hanziWord);
+  const [showWiki, setShowWiki] = useState(false);
+  const gloss =
+    meaning.data == null || meaning.data.gloss.length === 0
+      ? null
+      : glossOrThrow(hanziWord, meaning.data);
+
+  return (
+    <>
+      <Text
+        className={
+          context === `body` ? `hhh-text-body-ref` : `hhh-text-caption-ref`
+        }
+        onPress={() => {
+          setShowWiki(true);
+        }}
+      >
+        {`${hanziFromHanziWord(hanziWord)}${gloss == null ? `` : ` ${gloss}`}`}
+      </Text>
+      {showWiki ? (
+        <WikiHanziWordModal
+          hanziWord={hanziWord}
+          onDismiss={() => {
+            setShowWiki(false);
+          }}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/projects/app/src/client/ui/Hhhmark.tsx
+++ b/projects/app/src/client/ui/Hhhmark.tsx
@@ -1,32 +1,51 @@
 import { parseHhhmark } from "@/data/hhhmark";
 import { useMemo } from "react";
 import { Text } from "react-native";
+import { HanziWordRefText } from "./HanziWordRefText";
 
-export const Hhhmark = ({ source }: { source: string }) => {
+export const Hhhmark = ({
+  source,
+  context,
+}: {
+  source: string;
+  context: `body` | `caption`;
+}) => {
   const rendered = useMemo(() => {
     const parsed = parseHhhmark(source);
     return (
-      <Text>
+      <Text className="hhh-hhhmark">
         {parsed.map((node, index) => {
           switch (node.type) {
             case `text`: {
-              return <Text key={`text-${index}`}>{node.text}</Text>;
+              return (
+                <Text
+                  key={`text-${index}`}
+                  className={
+                    context === `body` ? `hhh-text-body` : `hhh-text-caption`
+                  }
+                >
+                  {node.text}
+                </Text>
+              );
             }
             case `hanziWord`: {
               return (
-                <Text
+                <HanziWordRefText
                   key={`hanziWord-${index}`}
-                  className="rounded bg-accent-10 px-1 font-medium tracking-tighter text-primary-4"
-                >
-                  {node.hanziWord}
-                </Text>
+                  context={context}
+                  hanziWord={node.hanziWord}
+                />
               );
             }
             case `bold`: {
               return (
                 <Text
                   key={`bold-${index}`}
-                  className="rounded bg-accent-10 px-1 font-medium tracking-tighter text-primary-4"
+                  className={
+                    context === `body`
+                      ? `hhh-text-body-bold`
+                      : `hhh-text-caption-bold`
+                  }
                 >
                   {node.text}
                 </Text>
@@ -36,7 +55,11 @@ export const Hhhmark = ({ source }: { source: string }) => {
               return (
                 <Text
                   key={`italic-${index}`}
-                  className="font-medium text-accent-10"
+                  className={
+                    context === `body`
+                      ? `hhh-text-body-italic`
+                      : `hhh-text-caption-italic`
+                  }
                 >
                   {node.text}
                 </Text>
@@ -46,7 +69,7 @@ export const Hhhmark = ({ source }: { source: string }) => {
         })}
       </Text>
     );
-  }, [source]);
+  }, [context, source]);
 
   return rendered;
 };

--- a/projects/app/src/client/ui/QuizDeck.tsx
+++ b/projects/app/src/client/ui/QuizDeck.tsx
@@ -2,9 +2,9 @@ import { questionsForReview2 } from "@/client/query";
 import type { StackNavigationFor } from "@/client/ui/types";
 import type {
   Mistake,
+  NewSkillRating,
   Question,
   QuestionFlag,
-  SkillRating,
 } from "@/data/model";
 import { MistakeType, QuestionType } from "@/data/model";
 import { Rating } from "@/util/fsrs";
@@ -93,7 +93,7 @@ export const QuizDeck = ({ className }: { className?: string }) => {
   });
 
   const handleRating = useEventCallback(
-    (ratings: SkillRating[], mistakes: Mistake[]) => {
+    (ratings: NewSkillRating[], mistakes: Mistake[]) => {
       invariant(ratings.length > 0, `ratings must not be empty`);
 
       const success = ratings.every(({ rating }) => rating !== Rating.Again);

--- a/projects/app/src/client/ui/QuizDeckMultipleChoiceQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckMultipleChoiceQuestion.tsx
@@ -1,7 +1,7 @@
 import type {
   Mistake,
   MultipleChoiceQuestion,
-  SkillRating,
+  NewSkillRating,
 } from "@/data/model";
 import { setAudioModeAsync, useAudioPlayer } from "expo-audio";
 import chunk from "lodash/chunk";
@@ -21,7 +21,7 @@ export const QuizDeckMultipleChoiceQuestion = memo(
   }: {
     question: MultipleChoiceQuestion;
     onNext: () => void;
-    onRating: (ratings: SkillRating[], mistakes: Mistake[]) => void;
+    onRating: (ratings: NewSkillRating[], mistakes: Mistake[]) => void;
   }) {
     const { prompt, choices } = question;
     const [selectedChoice, setSelectedChoice] = useState<string>();

--- a/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
@@ -379,7 +379,7 @@ const SkillChoice = ({ choice }: { choice: OneCorrectPairQuestionChoice }) => {
     case `gloss`: {
       return (
         <Text className={choiceGlossText({ small: true })}>
-          <Hhhmark source={choice.value} />
+          <Hhhmark source={choice.value} context="body" />
         </Text>
       );
     }

--- a/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
@@ -2,10 +2,10 @@ import { useHanziWordMeaning } from "@/client/hooks/useHanziWordMeaning";
 import { useMultiChoiceQuizTimer } from "@/client/hooks/useMultiChoiceQuizTimer";
 import type {
   Mistake,
+  NewSkillRating,
   OneCorrectPairQuestion,
   OneCorrectPairQuestionChoice,
   QuestionFlag,
-  SkillRating,
 } from "@/data/model";
 import { QuestionFlagType, SkillType } from "@/data/model";
 import type { HanziWordSkill, Skill } from "@/data/rizzleSchema";
@@ -64,7 +64,7 @@ export const QuizDeckOneCorrectPairQuestion = memo(
     question: OneCorrectPairQuestion;
     flag?: QuestionFlag;
     onNext: () => void;
-    onRating: (ratings: SkillRating[], mistakes: Mistake[]) => void;
+    onRating: (ratings: NewSkillRating[], mistakes: Mistake[]) => void;
   }) {
     const { prompt, answer, groupA, groupB } = question;
 
@@ -118,7 +118,7 @@ export const QuizDeckOneCorrectPairQuestion = memo(
             );
 
         const durationMs = (timer.endTime ?? Date.now()) - timer.startTime;
-        const skillRatings: SkillRating[] = [
+        const skillRatings: NewSkillRating[] = [
           computeSkillRating({
             skill: answer.skill,
             correct: isCorrect,

--- a/projects/app/src/client/ui/SkillRefText.tsx
+++ b/projects/app/src/client/ui/SkillRefText.tsx
@@ -1,0 +1,56 @@
+import { SkillType } from "@/data/model";
+import type {
+  DeprecatedSkill,
+  HanziWordSkill,
+  PinyinFinalAssociationSkill,
+  PinyinInitialAssociationSkill,
+  Skill,
+} from "@/data/rizzleSchema";
+import {
+  finalFromPinyinFinalAssociationSkill,
+  hanziWordFromSkill,
+  initialFromPinyinInitialAssociationSkill,
+  skillTypeFromSkill,
+  skillTypeToShorthand,
+} from "@/data/skills";
+import { Text } from "react-native";
+import { HanziWordRefText } from "./HanziWordRefText";
+
+export const SkillRefText = ({
+  skill,
+  context,
+}: {
+  skill: Skill;
+  context: `body` | `caption`;
+}) => {
+  switch (skillTypeFromSkill(skill)) {
+    case SkillType.PinyinFinalAssociation: {
+      skill = skill as PinyinFinalAssociationSkill;
+      return <Text>-{finalFromPinyinFinalAssociationSkill(skill)}</Text>;
+    }
+    case SkillType.PinyinInitialAssociation: {
+      skill = skill as PinyinInitialAssociationSkill;
+      return <Text>{initialFromPinyinInitialAssociationSkill(skill)}-</Text>;
+    }
+    case SkillType.Deprecated_RadicalToEnglish:
+    case SkillType.Deprecated_EnglishToRadical:
+    case SkillType.Deprecated_RadicalToPinyin:
+    case SkillType.Deprecated_PinyinToRadical:
+    case SkillType.Deprecated: {
+      skill = skill as DeprecatedSkill;
+      return <Text>{skillTypeToShorthand(skillTypeFromSkill(skill))}</Text>;
+    }
+    case SkillType.HanziWordToGloss:
+    case SkillType.HanziWordToPinyin:
+    case SkillType.HanziWordToPinyinInitial:
+    case SkillType.HanziWordToPinyinFinal:
+    case SkillType.HanziWordToPinyinTone:
+    case SkillType.GlossToHanziWord:
+    case SkillType.PinyinToHanziWord:
+    case SkillType.ImageToHanziWord: {
+      skill = skill as HanziWordSkill;
+      const hanziWord = hanziWordFromSkill(skill);
+      return <HanziWordRefText hanziWord={hanziWord} context={context} />;
+    }
+  }
+};

--- a/projects/app/src/client/ui/TextAnswerButton.tsx
+++ b/projects/app/src/client/ui/TextAnswerButton.tsx
@@ -188,7 +188,7 @@ export const TextAnswerButton = forwardRef<
           numberOfLines={2}
           ellipsizeMode="tail"
         >
-          <Hhhmark source={text} />
+          <Hhhmark source={text} context="body" />
         </Text>
       </View>
     </AnimatedPressable>

--- a/projects/app/src/client/ui/WikiHanziWordModal.tsx
+++ b/projects/app/src/client/ui/WikiHanziWordModal.tsx
@@ -2,14 +2,13 @@ import { useHanziWikiEntry } from "@/client/hooks/useHanziWikiEntry";
 import { useHanziWordMeaning } from "@/client/hooks/useHanziWordMeaning";
 import { splitHanziText } from "@/data/hanzi";
 import type { HanziWord } from "@/data/model";
-import { glossOrThrow, hanziFromHanziWord } from "@/dictionary/dictionary";
-import { useMemo, useState } from "react";
+import { hanziFromHanziWord } from "@/dictionary/dictionary";
+import { useMemo } from "react";
 import { ScrollView, Text, View } from "react-native";
-import { GlossHint } from "./GlossHint";
+import { HanziWordRefText } from "./HanziWordRefText";
 import { Hhhmark } from "./Hhhmark";
 import { PageSheetModal } from "./PageSheetModal";
 import { RectButton2 } from "./RectButton2";
-import type { PropsOf } from "./types";
 
 export const WikiHanziWordModal = ({
   hanziWord,
@@ -59,9 +58,10 @@ export const WikiHanziWordModal = ({
                   <Text className="font-karla text-xl text-text">
                     {hanziWordSkillData.data.gloss.join(`, `)}
                   </Text>
-                  <Text className="font-karla text-sm text-text/50">
-                    <Hhhmark source={hanziWordSkillData.data.definition} />
-                  </Text>
+                  <Hhhmark
+                    source={hanziWordSkillData.data.definition}
+                    context="caption"
+                  />
                 </View>
 
                 {wikiEntry.data?.components == null ? null : (
@@ -73,16 +73,17 @@ export const WikiHanziWordModal = ({
                       {wikiEntry.data.components.map((component, i) => {
                         return (
                           <View key={i} className="flex-column gap-1">
-                            <Text className="font-karla text-text">
+                            <Text className="hhh-text-body">
                               {component.title ??
                                 (component.hanziWord == null ? null : (
                                   <HanziWordRefText
                                     hanziWord={component.hanziWord}
+                                    context="body"
                                   />
                                 )) ??
                                 `???`}
                             </Text>
-                            <Text className="font-karla text-sm text-text/50">
+                            <Text className="hhh-text-caption">
                               {component.description}
                             </Text>
                           </View>
@@ -92,13 +93,40 @@ export const WikiHanziWordModal = ({
                       {hanziWordSkillData.data.glossHint == null ? null : (
                         <>
                           <View className="h-[1px] w-full bg-primary-8" />
-                          <GlossHint
-                            glossHint={hanziWordSkillData.data.glossHint}
-                            headlineClassName="font-karla text-text"
-                            explanationClassName="font-karla text-text opacity-80"
-                          />
+                          <Text className="hhh-text-body">
+                            <Hhhmark
+                              source={hanziWordSkillData.data.glossHint}
+                              context="body"
+                            />
+                          </Text>
                         </>
                       )}
+
+                      {wikiEntry.data.interpretation == null ? null : (
+                        <>
+                          <View className="h-[1px] w-full bg-primary-8" />
+                          <Text className="hhh-text-body">
+                            <Hhhmark
+                              source={wikiEntry.data.interpretation}
+                              context="body"
+                            />
+                          </Text>
+                        </>
+                      )}
+                    </View>
+                  </View>
+                )}
+
+                {wikiEntry.data?.visuallySimilar == null ? null : (
+                  <View className="gap-1 font-karla">
+                    <Text className="text-xs uppercase text-primary-10">
+                      Visually Similar
+                    </Text>
+
+                    <View className="flex-row flex-wrap gap-2 text-text">
+                      {wikiEntry.data.visuallySimilar.map((hanzi, i) => (
+                        <Text key={i}>{hanzi}</Text>
+                      ))}
                     </View>
                   </View>
                 )}
@@ -122,38 +150,5 @@ export const WikiHanziWordModal = ({
   );
 };
 
-const RefText = (props: Omit<PropsOf<typeof Text>, `className`>) => (
-  <Text
-    className="underline decoration-text/50 decoration-dashed decoration-[1.5px] underline-offset-[6px]"
-    {...props}
-  />
-);
-
-export const HanziWordRefText = ({ hanziWord }: { hanziWord: HanziWord }) => {
-  const meaning = useHanziWordMeaning(hanziWord);
-  const [showWiki, setShowWiki] = useState(false);
-  const gloss =
-    meaning.data == null || meaning.data.gloss.length === 0
-      ? null
-      : glossOrThrow(hanziWord, meaning.data);
-
-  return (
-    <>
-      <RefText
-        onPress={() => {
-          setShowWiki(true);
-        }}
-      >
-        {`${hanziFromHanziWord(hanziWord)}${gloss == null ? `` : ` ${gloss}`}`}
-      </RefText>
-      {showWiki ? (
-        <WikiHanziWordModal
-          hanziWord={hanziWord}
-          onDismiss={() => {
-            setShowWiki(false);
-          }}
-        />
-      ) : null}
-    </>
-  );
-};
+// eslint-disable-next-line import/no-default-export
+export default WikiHanziWordModal;

--- a/projects/app/src/data/model.ts
+++ b/projects/app/src/data/model.ts
@@ -216,7 +216,7 @@ export type Mistake =
   | HanziPinyinMistake
   | HanziPinyinInitialMistake;
 
-export interface SkillRating {
+export interface NewSkillRating {
   skill: Skill;
   rating: Rating;
   durationMs: number;

--- a/projects/app/src/data/rizzleSchema.ts
+++ b/projects/app/src/data/rizzleSchema.ts
@@ -300,3 +300,7 @@ export type Rizzle = RizzleReplicache<typeof v7>;
 export type SkillState = NonNullable<
   Awaited<ReturnType<typeof v7.skillState.get>>
 >;
+
+export type SkillRating = NonNullable<
+  Awaited<ReturnType<typeof v7.skillRating.get>>
+>;

--- a/projects/app/src/dictionary/dictionary.asset.json
+++ b/projects/app/src/dictionary/dictionary.asset.json
@@ -986,7 +986,7 @@
 ["字典:dictionary",{"gloss":["dictionary"],"pinyin":["zì diǎn"],"example":"我需要一本字典。","partOfSpeech":"noun","definition":"A reference book containing words and their meanings."}],
 ["存:store",{"gloss":["save","store"],"pinyin":["cún"],"example":"把文件存到硬盘。","partOfSpeech":"verb","definition":"To keep or store something for future use."}],
 ["存在:exist",{"gloss":["exist","be present"],"pinyin":["cún zài"],"example":"这种问题一直存在。","partOfSpeech":"verb","definition":"To have an existence or to be present."}],
-["学:learn",{"gloss":["learn"],"glossHint":"Imagine a child (子) under a blanket (冖) trying to learn how to count using their fingers (𭕄)","pinyin":["xué"],"example":"他在学汉语。","partOfSpeech":"verb","definition":"To acquire knowledge or skill in a subject or activity by study, experience, or being taught."}],
+["学:learn",{"gloss":["learn"],"glossHint":"Imagine a {子:child} under a blanket (冖) trying to learn how to count using their fingers (𭕄)","pinyin":["xué"],"example":"他在学汉语。","partOfSpeech":"verb","definition":"To acquire knowledge or skill in a subject or activity by study, experience, or being taught."}],
 ["学习:study",{"gloss":["study","learn"],"pinyin":["xué xí"],"example":"她每天学习两个小时。","partOfSpeech":"verb","definition":"The act of acquiring knowledge or skill by studying, practicing, being taught, or experiencing something."}],
 ["学期:semester",{"gloss":["semester"],"pinyin":["xué qī"],"example":"新学期开始了。","partOfSpeech":"noun","definition":"A half-year term in a school or university, typically lasting 15 to 18 weeks."}],
 ["学校:school",{"gloss":["school"],"pinyin":["xué xiào"],"example":"她去学校上课。","partOfSpeech":"noun","definition":"An institution for educating children or providing specialized instruction."}],

--- a/projects/app/src/dictionary/dictionary.ts
+++ b/projects/app/src/dictionary/dictionary.ts
@@ -367,16 +367,23 @@ export const loadDictionary = memoize0(async () =>
 export const wikiEntrySchema = z.object({
   componentsIdc: z
     .string()
-    .describe(`Ideographic Description Character for the components, e.g. ⿰`),
-  components: z.array(
-    z.object({
-      hanziWord: hanziWordSchema
-        .describe(`Optional link to a specific hanzi word`)
-        .optional(),
-      title: z.string().optional(),
-      description: z.string().optional(),
-    }),
-  ),
+    .describe(`Ideographic Description Character for the components, e.g. ⿰`)
+    .optional(),
+  components: z
+    .array(
+      z.object({
+        hanziWord: hanziWordSchema
+          .describe(`Optional link to a specific hanzi word`)
+          .optional(),
+        title: z.string().optional(),
+        description: z.string().optional(),
+      }),
+    )
+    .optional(),
+  interpretation: z
+    .string()
+    .describe(`Interpretation of the character`)
+    .optional(),
   mnemonics: z
     .array(
       z.object({
@@ -394,7 +401,7 @@ export const wikiEntrySchema = z.object({
     )
     .optional()
     .nullable(),
-  visuallySimilar: z.array(hanziWordSchema).optional().nullable(),
+  visuallySimilar: z.array(hanziTextSchema).optional().nullable(),
 });
 
 export type WikiEntry = z.infer<typeof wikiEntrySchema>;

--- a/projects/app/src/dictionary/wiki.asset.json
+++ b/projects/app/src/dictionary/wiki.asset.json
@@ -16,6 +16,38 @@
           "hanziWord": "子:child",
           "description": "Can mean each / every (and serves as the phonetic component)"
         }
+      ],
+      "visuallySimilar": [
+        "觉"
+      ]
+    }
+  ],
+  [
+    "觉",
+    {
+      "visuallySimilar": [
+        "学"
+      ]
+    }
+  ],
+  [
+    "会",
+    {
+      "componentsIdc": "⿱",
+      "components": [
+        {
+          "hanziWord": "人:person",
+          "description": "A person standing up."
+        },
+        {
+          "hanziWord": "云:cloud",
+          "description": "A cloud (originally also “say” or “speech” in ancient scripts)."
+        }
+      ],
+      "interpretation": "Although it might feel intuitive to interpret 云 as being “above” the person (since clouds are above people), **the actual character has 人 on top** and 云 underneath.\n\nWhat might this symbolize?\n• A {人:person} standing over or leading a **group / thought / idea** (云).\n• Or a **person coming together over shared speech** (云) — pointing to meanings like:\n\t• to meet\n\t• to understand\n\t• to be able to do something (as in potential)\n• a meeting or event",
+      "visuallySimilar": [
+        "金",
+        "舍"
       ]
     }
   ]

--- a/projects/app/src/global.css
+++ b/projects/app/src/global.css
@@ -36,12 +36,41 @@
   }
   /* end .hhh-text-title */
 
+  .hhh-hhhmark {
+    white-space: pre-wrap;
+    tab-size: 2;
+  }
+
   .hhh-text-body {
-    @apply font-sans text-primary-12;
+    @apply font-sans font-thin leading-normal text-primary-12/90;
+  }
+
+  .hhh-text-body-ref {
+    @apply font-sans font-normal leading-normal text-primary-12 underline decoration-primary-12/50 decoration-dashed decoration-[1.5px] underline-offset-[5px];
+  }
+
+  .hhh-text-body-bold {
+    @apply font-sans font-medium leading-normal text-primary-12;
+  }
+
+  .hhh-text-body-italic {
+    @apply font-sans font-medium italic leading-normal text-primary-12;
   }
 
   .hhh-text-caption {
-    @apply font-karla text-sm leading-normal text-primary-11;
+    @apply font-sans text-sm font-light leading-normal text-primary-12/50;
+  }
+
+  .hhh-text-caption-ref {
+    @apply font-sans text-sm font-normal leading-normal text-primary-12/80 underline decoration-primary-12/50 decoration-dashed decoration-[1.5px] underline-offset-[5px];
+  }
+
+  .hhh-text-caption-bold {
+    @apply font-sans text-sm font-medium leading-normal text-primary-12/50;
+  }
+
+  .hhh-text-caption-italic {
+    @apply font-sans text-sm font-light italic leading-normal text-primary-12/50;
   }
 
   /* www */

--- a/projects/app/test/client/query.test.ts
+++ b/projects/app/test/client/query.test.ts
@@ -34,7 +34,7 @@ await test(`${simulateSkillReviews.name} returns a review queue`, async () => {
     history: [],
   });
 
-  assert.partialDeepStrictEqual(reviewQueue, {
+  expect(reviewQueue).toMatchObject({
     available: [`he:丿:slash`, `he:𠃌:radical`, `he:八:eight`],
     blocked: [`he:刀:knife`, `he:分:divide`],
   });
@@ -68,7 +68,7 @@ await test(`${computeSkillReviewQueue.name} suite`, async () => {
       history: [`🟡 he:丿:slash`, `💤 1m`],
     });
 
-    assert.partialDeepStrictEqual(reviewQueue, {
+    expect(reviewQueue).toMatchObject({
       available: [`he:𠃌:radical`, `he:八:eight`, `he:丿:slash`],
       blocked: [`he:刀:knife`, `he:分:divide`],
     });
@@ -152,7 +152,7 @@ await test(`${computeSkillReviewQueue.name} suite`, async () => {
         targetSkills,
         history,
       });
-      assert.partialDeepStrictEqual(queue, {
+      expect(queue).toMatchObject({
         available: [
           `he:刀:knife`,
           // These come later because he:刀:knife is due.
@@ -160,7 +160,8 @@ await test(`${computeSkillReviewQueue.name} suite`, async () => {
           `he:𠃌:radical`,
         ],
         blocked: [],
-        dueCount: 1,
+        retryCount: 1,
+        dueCount: 0,
         overDueCount: 0,
       });
     }
@@ -172,12 +173,13 @@ await test(`${computeSkillReviewQueue.name} suite`, async () => {
         targetSkills,
         history,
       });
-      assert.partialDeepStrictEqual(queue, {
+      expect(queue).toMatchObject({
         available: [`he:丿:slash`, `he:𠃌:radical`],
         blocked: [
           // Now this comes last because it's "stale" and reset to new.
           `he:刀:knife`,
         ],
+        retryCount: 0,
         dueCount: 0,
         overDueCount: 0,
       });

--- a/projects/app/test/client/ui/Hhhmark.test.tsx
+++ b/projects/app/test/client/ui/Hhhmark.test.tsx
@@ -6,7 +6,7 @@ await test(`${Hhhmark.name} suite`, async (t) => {
   await t.test(`renders correctly with dumb quotes`, async () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- bug in no-unsafe-assignment
     const { root } = render(
-      <Hhhmark source={`This is a 'test' with "dumb quotes"`} />,
+      <Hhhmark source={`This is a 'test' with "dumb quotes"`} context="body" />,
     );
     expect(root).toHaveTextContent(`This is a ‘test’ with “dumb quotes”`);
   });

--- a/projects/app/test/data/helpers.test.ts
+++ b/projects/app/test/data/helpers.test.ts
@@ -1,7 +1,7 @@
 import { fsrsIsStable, Rating } from "#util/fsrs.ts";
 import assert from "node:assert/strict";
 import test from "node:test";
-import { fsrsSrsState, parseRelativeTimeShorthand } from "./helpers";
+import { date, fsrsSrsState, parseRelativeTimeShorthand } from "./helpers";
 
 await test(`${parseRelativeTimeShorthand.name} suite`, async (t) => {
   await t.test(`assumes positive without a sign`, () => {
@@ -25,6 +25,16 @@ await test(`${parseRelativeTimeShorthand.name} suite`, async (t) => {
       parseRelativeTimeShorthand(`+5m`, now),
       new Date(now.getTime() + 5 * 60 * 1000),
     );
+  });
+});
+
+await test(`${date.name} suite`, async (t) => {
+  await t.test(`parses values`, (t) => {
+    t.mock.timers.enable({ apis: [`Date`] });
+    t.mock.timers.setTime(new Date(`2025-01-01T00:00:00Z`).getTime());
+
+    expect(date`+1d`).toEqual(parseRelativeTimeShorthand(`+1d`));
+    expect(date`+1m`).toEqual(parseRelativeTimeShorthand(`+1m`));
   });
 });
 

--- a/projects/app/test/data/helpers.ts
+++ b/projects/app/test/data/helpers.ts
@@ -39,6 +39,13 @@ export function makeMockTx(t: TestContext) {
   };
 }
 
+export const date = (strings: TemplateStringsArray): Date => {
+  const shorthand = strings.reduce((acc, str) => acc + str, ``);
+  return parseRelativeTimeShorthand(shorthand);
+};
+
+export const 时 = date;
+
 /**
  * Convert a string like "+1d" or "-5s" to a date.
  */
@@ -57,14 +64,13 @@ export const parseRelativeTimeShorthand = (
 };
 
 export const mockSrsState = (
-  prevReviewAtShorthand: string,
-  nextReviewAtShorthand: string,
-  now = new Date(),
+  prevReviewAt: Date,
+  nextReviewAt: Date,
 ): SrsStateMock => {
   return {
     type: SrsType.Mock,
-    prevReviewAt: parseRelativeTimeShorthand(prevReviewAtShorthand, now),
-    nextReviewAt: parseRelativeTimeShorthand(nextReviewAtShorthand, now),
+    prevReviewAt,
+    nextReviewAt,
   };
 };
 

--- a/projects/app/test/dictionary/dictionary.test.ts
+++ b/projects/app/test/dictionary/dictionary.test.ts
@@ -441,6 +441,23 @@ await test(`all word lists only reference valid hanzi words`, async () => {
   }
 });
 
+await test(`all wiki component hanzi words reference valid hanzi words`, async () => {
+  const wiki = await loadWiki();
+  for (const [hanzi, wikiEntry] of wiki) {
+    if (wikiEntry.components != null) {
+      for (const { hanziWord } of wikiEntry.components) {
+        if (hanziWord != null) {
+          assert.notEqual(
+            await lookupHanziWord(hanziWord),
+            null,
+            `missing hanzi word lookup for ${hanziWord} in wiki entry ${hanzi}`,
+          );
+        }
+      }
+    }
+  }
+});
+
 await test(`expect missing glyphs to be included decomposition data`, async () => {
   const allChars = await allHanziCharacters();
   const allComponents = new Set<string>();

--- a/projects/app/test/server/lib/replicache.test.ts
+++ b/projects/app/test/server/lib/replicache.test.ts
@@ -256,12 +256,11 @@ await test(`${push.name} suite`, async (t) => {
             mutations: [mut],
           });
 
-          assert.partialDeepStrictEqual(
+          expect(
             await tx.query.replicacheClient.findFirst({
               where: (t, { eq }) => eq(t.id, client.id),
             }),
-            { lastMutationId: mut.id },
-          );
+          ).toMatchObject({ lastMutationId: mut.id });
         },
       );
 
@@ -341,7 +340,7 @@ await test(`${pull.name} suite`, async (t) => {
           where: (t, { eq }) => eq(t.userId, user.id),
         });
 
-        assert.partialDeepStrictEqual(clientGroup, { cvrVersion: 1 });
+        expect(clientGroup).toMatchObject({ cvrVersion: 1 });
       });
 
       await txTest(
@@ -397,7 +396,7 @@ await test(`${pull.name} suite`, async (t) => {
           );
 
           // The CVR should have the lastMutationIds for the clients in the group
-          assert.partialDeepStrictEqual(cvr, {
+          expect(cvr).toMatchObject({
             lastMutationIds: { [client.id]: 66 },
             entities: expectedEntities,
           });
@@ -527,7 +526,7 @@ await test(`${pull.name} suite`, async (t) => {
           cookie: null,
         });
 
-        assert.partialDeepStrictEqual(result, {
+        expect(result).toMatchObject({
           cookie: {
             order: 1,
           },
@@ -582,7 +581,7 @@ await test(`${pull.name} suite`, async (t) => {
           cookie: pull1.cookie,
         });
 
-        assert.partialDeepStrictEqual(pull2, {
+        expect(pull2).toMatchObject({
           cookie: {
             order: 2,
           },
@@ -637,7 +636,7 @@ await test(`${pull.name} suite`, async (t) => {
           cookie: pull1.cookie,
         });
 
-        assert.partialDeepStrictEqual(pull2, {
+        expect(pull2).toMatchObject({
           cookie: {
             order: 2,
           },
@@ -679,7 +678,7 @@ await test(`${pull.name} suite`, async (t) => {
           cookie: null,
         });
 
-        assert.partialDeepStrictEqual(pull1, {
+        expect(pull1).toMatchObject({
           patch: [
             {
               op: `clear`,

--- a/projects/app/test/util/rizzle.test.ts
+++ b/projects/app/test/util/rizzle.test.ts
@@ -749,7 +749,7 @@ await test(`.getIndexes()`, () => {
         name: r.string().indexed(`byAuthorName`),
       }),
     });
-    assert.partialDeepStrictEqual(posts.getIndexes(), {
+    expect(posts.getIndexes()).toMatchObject({
       byAuthorName: {
         allowEmpty: false,
         prefix: `foo`,
@@ -767,13 +767,13 @@ await test(`.getIndexes()`, () => {
       }),
     });
 
-    assert.partialDeepStrictEqual(posts._def.valueType._getIndexes(), {
+    expect(posts._def.valueType._getIndexes()).toMatchObject({
       byAuthorName: {
         allowEmpty: false,
         jsonPointer: `/author/name`,
       },
     });
-    assert.partialDeepStrictEqual(posts.getIndexes(), {
+    expect(posts.getIndexes()).toMatchObject({
       byAuthorName: {
         allowEmpty: false,
         prefix: `foo/`,
@@ -789,7 +789,7 @@ await test(`.getIndexes()`, () => {
       name: r.string().indexed(`byAuthorName`).nullable(),
     });
 
-    assert.partialDeepStrictEqual(posts.getIndexes(), {
+    expect(posts.getIndexes()).toMatchObject({
       byAuthorName: {
         allowEmpty: false,
         prefix: `foo/`,
@@ -805,7 +805,7 @@ await test(`.getIndexes()`, () => {
       name: r.string().alias(`n`).indexed(`byAuthorName`).nullable(),
     });
 
-    assert.partialDeepStrictEqual(posts.getIndexes(), {
+    expect(posts.getIndexes()).toMatchObject({
       byAuthorName: {
         allowEmpty: false,
         prefix: `foo/`,
@@ -821,7 +821,7 @@ await test(`.getIndexes()`, () => {
       name: r.string().indexed(`byAuthorName`).optional(),
     });
 
-    assert.partialDeepStrictEqual(posts.getIndexes(), {
+    expect(posts.getIndexes()).toMatchObject({
       byAuthorName: {
         allowEmpty: false,
         prefix: `foo/`,
@@ -837,7 +837,7 @@ await test(`.getIndexes()`, () => {
       name: r.string().alias(`n`).indexed(`byAuthorName`).optional(),
     });
 
-    assert.partialDeepStrictEqual(posts.getIndexes(), {
+    expect(posts.getIndexes()).toMatchObject({
       byAuthorName: {
         allowEmpty: false,
         prefix: `foo/`,
@@ -853,7 +853,7 @@ await test(`.getIndexes()`, () => {
       name: r.string().indexed(`byAuthorName`).alias(`n`),
     });
 
-    assert.partialDeepStrictEqual(posts.getIndexes(), {
+    expect(posts.getIndexes()).toMatchObject({
       byAuthorName: {
         allowEmpty: false,
         prefix: `foo/`,
@@ -986,7 +986,7 @@ await test(`replicache()`, async (t) => {
         mapValues(options.mutators, (v) => typeof v),
         { cp: `function` },
       );
-      assert.partialDeepStrictEqual(options.indexes, {
+      expect(options.indexes).toMatchObject({
         "posts.byTitle": {
           allowEmpty: false,
           jsonPointer: `/r`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced components to display Hanzi words with gloss and detailed modals, including visual similarity and interpretation sections.
  - Added new dictionary entries for "觉" and "会", with enhanced metadata and visual similarity links.
  - Skill review queue now prioritizes skills needing immediate retry after incorrect answers, and displays a retry count.

- **Improvements**
  - Unified skill reference rendering across the app for consistency.
  - Enhanced text styling for body and caption contexts, with refined typography and semantic classes.
  - Expanded dictionary schema to support interpretations and visual similarity.

- **Bug Fixes**
  - Ensured all wiki component Hanzi words reference valid dictionary entries.

- **Tests**
  - Added and updated tests to cover retry logic in skill reviews and validate dictionary references.
  - Migrated test assertions to Jest for improved consistency.

- **Chores**
  - Refactored code for maintainability, including type renaming and component extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->