### PR TITLE
allow omitting the gloss in hhhmark

### DIFF
--- a/projects/app/src/client/ui/Hhhmark.tsx
+++ b/projects/app/src/client/ui/Hhhmark.tsx
@@ -16,16 +16,6 @@ export const hhhText = tv({
   },
 });
 
-export const hhhTextRef = tv({
-  variants: {
-    context: {
-      [`body-2xl`]: `hhh-text-body-2xl-ref`,
-      body: `hhh-text-body-ref`,
-      caption: `hhh-text-caption-ref`,
-    },
-  },
-});
-
 export const hhhTextBold = tv({
   variants: {
     context: {
@@ -72,6 +62,7 @@ export const Hhhmark = ({
                   key={`hanziWord-${index}`}
                   context={context}
                   hanziWord={node.hanziWord}
+                  showGloss={node.showGloss}
                 />
               );
             }

--- a/projects/app/src/dictionary/wiki.asset.json
+++ b/projects/app/src/dictionary/wiki.asset.json
@@ -71,5 +71,22 @@
       ],
       "interpretation": "① **One** voice (口) speaks under a single command (一), all under the control of a higher authority (𠃌 wrapping stroke) — someone is in **charge**.\n\nOr more vivid:\n\n② Imagine a **manager’s voice** (口) under a **single rule** (一) — all wrapped tightly by an **enclosure** (𠃌) like a rolled scroll or decree. The person speaking isn’t just talking — they speak with **authority**. This is someone who **oversees, commands**, or **manages**."
     }
+  ],
+  [
+    "钟",
+    {
+      "componentsIdc": "⿰",
+      "components": [
+        {
+          "hanziWord": "钅:metal",
+          "description": "Indicates the object is made of metal — commonly used for tools, coins, and instruments."
+        },
+        {
+          "hanziWord": "中:middle",
+          "description": "Gives the sound zhōng and suggests something resonating from the center"
+        }
+      ],
+      "interpretation": "A metal ({钅:-metal}) object that resonates from its center ({中:-middle}) — a bell, and by extension, clocks."
+    }
   ]
 ]

--- a/projects/app/test/data/hhhmark.test.ts
+++ b/projects/app/test/data/hhhmark.test.ts
@@ -24,6 +24,26 @@ await test(`${parseHhhmark.name} suite`, async () => {
       {
         hanziWord: `好:good`,
         type: `hanziWord`,
+        showGloss: true,
+      },
+      {
+        text: `.`,
+        type: `text`,
+      },
+    ]);
+  });
+
+  await test(`parses HanziWord references with omitted gloss`, async () => {
+    const nodes = parseHhhmark(`See also {好:-good}.`);
+    assert.deepEqual(nodes, [
+      {
+        text: `See also `,
+        type: `text`,
+      },
+      {
+        hanziWord: `好:good`,
+        type: `hanziWord`,
+        showGloss: false,
       },
       {
         text: `.`,


### PR DESCRIPTION
e.g. `{中:-middle}` -> "中" rather than "中 middle"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selectively hiding or showing glosses for HanziWord references using a new syntax.
  - Introduced a new dictionary entry for the Chinese character "钟" with detailed component breakdown and interpretation.

- **Bug Fixes**
  - Improved parsing logic to correctly handle gloss visibility for HanziWord references.

- **Tests**
  - Expanded test coverage to verify correct parsing and gloss visibility behavior for HanziWord references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->