### PR TITLE
add "new count" to the quiz queue

### DIFF
--- a/projects/app/src/app/(sidenav)/learn/history/index.tsx
+++ b/projects/app/src/app/(sidenav)/learn/history/index.tsx
@@ -106,9 +106,9 @@ export default function HistoryPage() {
         </View> */}
         <View className="flex-row gap-2">
           <View className="flex-1 items-center gap-[10px]">
-            <Text className="text-xl text-body">available queue</Text>
+            <Text className="text-xl text-body">queue items</Text>
 
-            {data2Query.data?.available.slice(0, 100).map((skill, i) => (
+            {data2Query.data?.items.slice(0, 100).map((skill, i) => (
               <View key={i} className="flex-col items-center">
                 <SkillRefText skill={skill} context="body" />
                 <Text className="hhh-text-caption">

--- a/projects/app/src/app/dev/ui.tsx
+++ b/projects/app/src/app/dev/ui.tsx
@@ -729,26 +729,44 @@ function QuizProgressBarExample() {
 function QuizQueueButtonExample() {
   return (
     <View className="w-full flex-row gap-2">
-      <ExampleStack title="default">
-        <QuizQueueButton />
+      <ExampleStack title="loading">
+        <QuizQueueButton queueStats={null} />
       </ExampleStack>
 
       <ExampleStack title="overdue">
-        <QuizQueueButton overdueCount={1} />
-        <QuizQueueButton overdueCount={10} />
-        <QuizQueueButton overdueCount={100} />
+        <QuizQueueButton
+          queueStats={{ overDueCount: 1, dueCount: 0, newCount: 0 }}
+        />
+        <QuizQueueButton
+          queueStats={{ overDueCount: 10, dueCount: 0, newCount: 0 }}
+        />
+        <QuizQueueButton
+          queueStats={{ overDueCount: 100, dueCount: 0, newCount: 0 }}
+        />
       </ExampleStack>
 
       <ExampleStack title="due">
-        <QuizQueueButton dueCount={1} />
-        <QuizQueueButton dueCount={10} />
-        <QuizQueueButton dueCount={100} />
+        <QuizQueueButton
+          queueStats={{ overDueCount: 0, dueCount: 1, newCount: 0 }}
+        />
+        <QuizQueueButton
+          queueStats={{ overDueCount: 0, dueCount: 10, newCount: 0 }}
+        />
+        <QuizQueueButton
+          queueStats={{ overDueCount: 0, dueCount: 100, newCount: 0 }}
+        />
       </ExampleStack>
 
       <ExampleStack title="new">
-        <QuizQueueButton newCount={1} />
-        <QuizQueueButton newCount={10} />
-        <QuizQueueButton newCount={100} />
+        <QuizQueueButton
+          queueStats={{ overDueCount: 0, dueCount: 0, newCount: 1 }}
+        />
+        <QuizQueueButton
+          queueStats={{ overDueCount: 0, dueCount: 0, newCount: 10 }}
+        />
+        <QuizQueueButton
+          queueStats={{ overDueCount: 0, dueCount: 0, newCount: 100 }}
+        />
       </ExampleStack>
     </View>
   );

--- a/projects/app/src/client/query.ts
+++ b/projects/app/src/client/query.ts
@@ -24,7 +24,7 @@ export async function questionsForReview2(
   const questions: Question[] = [];
   const reviewQueue = await targetSkillsReviewQueue(r);
 
-  for (const [i, skill] of reviewQueue.available.entries()) {
+  for (const [i, skill] of reviewQueue.items.entries()) {
     const skillState = await r.replicache.query((tx) =>
       r.query.skillState.get(tx, { skill }),
     );

--- a/projects/app/src/client/ui/QuizDeck.tsx
+++ b/projects/app/src/client/ui/QuizDeck.tsx
@@ -172,11 +172,7 @@ export const QuizDeck = ({ className }: { className?: string }) => {
       <View className="mb-[20px] w-full max-w-[600px] flex-row items-center gap-[24px] self-center px-quiz-px">
         <CloseButton />
         <QuizProgressBar progress={quizProgress.progress} />
-        <QuizQueueButton
-          overdueCount={reviewQueue?.overDueCount}
-          dueCount={reviewQueue?.dueCount}
-          newCount={0}
-        />
+        <QuizQueueButton queueStats={reviewQueue} />
       </View>
 
       <NavigationIndependentTree>

--- a/projects/app/src/client/ui/QuizQueueButton.tsx
+++ b/projects/app/src/client/ui/QuizQueueButton.tsx
@@ -1,15 +1,15 @@
+import type { SkillReviewQueue } from "@/data/skills";
 import { Image } from "expo-image";
 import { Text, View } from "react-native";
 import { tv } from "tailwind-variants";
 
 export function QuizQueueButton({
-  overdueCount,
-  dueCount,
-  newCount,
+  queueStats,
 }: {
-  overdueCount?: number;
-  dueCount?: number;
-  newCount?: number;
+  queueStats: Pick<
+    SkillReviewQueue,
+    `overDueCount` | `dueCount` | `newCount`
+  > | null;
 }) {
   return (
     <View className="relative size-[32px] flex-row justify-center md:justify-start">
@@ -19,14 +19,12 @@ export function QuizQueueButton({
         tintColor="currentColor"
         contentFit="fill"
       />
-      {overdueCount == null ||
-      dueCount == null ||
-      newCount == null ? null : overdueCount > 0 ? (
-        <CountLozenge count={overdueCount} mode="overdue" />
-      ) : dueCount > 0 ? (
-        <CountLozenge count={dueCount} mode="due" />
-      ) : newCount > 0 ? (
-        <CountLozenge count={newCount} mode="new" />
+      {queueStats == null ? null : queueStats.overDueCount > 0 ? (
+        <CountLozenge count={queueStats.overDueCount} mode="overdue" />
+      ) : queueStats.dueCount > 0 ? (
+        <CountLozenge count={queueStats.dueCount} mode="due" />
+      ) : queueStats.newCount > 0 ? (
+        <CountLozenge count={queueStats.newCount} mode="new" />
       ) : (
         <CheckBadge />
       )}

--- a/projects/app/src/data/skills.ts
+++ b/projects/app/src/data/skills.ts
@@ -372,11 +372,28 @@ export function pinyinInitialAssociation(
 }
 
 export interface SkillReviewQueue {
-  available: readonly Skill[];
-  blocked: readonly Skill[];
+  /**
+   * The skills in the review queue.
+   */
+  items: readonly Skill[];
+  /**
+   * Skills that are blocked from being reviewed (or introduced) because their
+   * dependencies aren't met yet.
+   */
+  blockedItems: readonly Skill[];
+  /**
+   * The number of items in the queue that need to be retried because they were
+   * answered incorrectly.
+   */
   retryCount: number;
+  /**
+   * The number of items in the queue due for review.
+   */
   dueCount: number;
-  overDueCount: number;
+  /**
+   * The number of new (never seen before) items in the queue.
+   */
+  newCount: number;
   /**
    * When the number of "due" items will increase.
    */
@@ -385,6 +402,10 @@ export interface SkillReviewQueue {
    * When the number of "over due" items will increase.
    */
   newOverDueAt: Date | null;
+  /**
+   * The number of items in the queue overdue for review.
+   */
+  overDueCount: number;
 }
 
 export function skillReviewQueue({
@@ -551,7 +572,7 @@ export function skillReviewQueue({
     }
   }
 
-  const available = [
+  const items = [
     // First do incorrect answers that need to be retried.
     ...learningOrderRetry
       .sort(sortComparatorDate(([, when]) => when))
@@ -570,14 +591,15 @@ export function skillReviewQueue({
     // Finally sort the not-due skills.
     ...randomSortSkills(learningOrderNotDue),
   ];
-  const blocked = learningOrderBlocked.reverse();
+  const blockedItems = learningOrderBlocked.reverse();
 
   return {
-    available,
-    blocked,
+    items,
+    blockedItems,
     retryCount: learningOrderRetry.length,
     dueCount: learningOrderDue.length,
     overDueCount: learningOrderOverDue.length,
+    newCount: learningOrderNew.length,
     newDueAt,
     newOverDueAt,
   };

--- a/projects/app/test/client/query.test.ts
+++ b/projects/app/test/client/query.test.ts
@@ -23,8 +23,8 @@ await test(`${targetSkillsReviewQueue.name} suite`, async () => {
     await using rizzle = r.replicache(testReplicacheOptions(), v7, v7Mutators);
 
     // Sanity check that there should be a bunch in the queue
-    const { available } = await targetSkillsReviewQueue(rizzle);
-    assert.ok(available.length > 100);
+    const { items } = await targetSkillsReviewQueue(rizzle);
+    assert.ok(items.length > 100);
   });
 });
 
@@ -35,14 +35,14 @@ await test(`${simulateSkillReviews.name} returns a review queue`, async () => {
   });
 
   expect(reviewQueue).toMatchObject({
-    available: [`he:丿:slash`, `he:𠃌:radical`, `he:八:eight`],
-    blocked: [`he:刀:knife`, `he:分:divide`],
+    items: [`he:丿:slash`, `he:𠃌:radical`, `he:八:eight`],
+    blockedItems: [`he:刀:knife`, `he:分:divide`],
   });
 });
 
 await test(`${computeSkillReviewQueue.name} suite`, async () => {
   await test(`incorrect answers in a quiz don't get scheduled prematurely`, async () => {
-    const { available } = await simulateSkillReviews({
+    const { items } = await simulateSkillReviews({
       targetSkills: [`he:分:divide`],
       history: [
         // first question is 丿:slash but they get it wrong. 八 is one of the
@@ -54,8 +54,8 @@ await test(`${computeSkillReviewQueue.name} suite`, async () => {
 
     // Make sure 八 didn't jump the queue before 𠃌 because it hasn't been
     // introduced yet, instead they should have to answer 𠃌 again.
-    const 𠃌Index = available.indexOf(`he:𠃌:radical`);
-    const 八Index = available.indexOf(`he:八:eight`);
+    const 𠃌Index = items.indexOf(`he:𠃌:radical`);
+    const 八Index = items.indexOf(`he:八:eight`);
     assert.ok(
       𠃌Index < 八Index,
       `he:𠃌:radical should be scheduled before he:八:eight`,
@@ -69,8 +69,8 @@ await test(`${computeSkillReviewQueue.name} suite`, async () => {
     });
 
     expect(reviewQueue).toMatchObject({
-      available: [`he:𠃌:radical`, `he:八:eight`, `he:丿:slash`],
-      blocked: [`he:刀:knife`, `he:分:divide`],
+      items: [`he:𠃌:radical`, `he:八:eight`, `he:丿:slash`],
+      blockedItems: [`he:刀:knife`, `he:分:divide`],
     });
   });
 
@@ -79,40 +79,52 @@ await test(`${computeSkillReviewQueue.name} suite`, async () => {
     const history: SkillReviewOp[] = [];
 
     {
-      const { blocked } = await simulateSkillReviews({ targetSkills, history });
-      assert.deepEqual(blocked, [`he:刀:knife`]);
-    }
-
-    history.push(`💤 1d`, `🟢 he:丿:slash he:𠃌:radical`);
-
-    {
-      const { blocked } = await simulateSkillReviews({ targetSkills, history });
-      assert.deepEqual(blocked, [`he:刀:knife`]);
-    }
-
-    history.push(`💤 1d`, `🟢 he:丿:slash he:𠃌:radical`);
-
-    {
-      const { blocked } = await simulateSkillReviews({ targetSkills, history });
-      assert.deepEqual(blocked, [`he:刀:knife`]);
-    }
-
-    history.push(`💤 1d`, `🟢 he:丿:slash he:𠃌:radical`);
-
-    {
-      const { blocked } = await simulateSkillReviews({ targetSkills, history });
-      assert.deepEqual(blocked, [`he:刀:knife`]);
-    }
-
-    history.push(`💤 1d`, `🟢 he:丿:slash he:𠃌:radical`);
-
-    {
-      const { available, blocked } = await simulateSkillReviews({
+      const { blockedItems } = await simulateSkillReviews({
         targetSkills,
         history,
       });
-      expect(available).toContain(`he:刀:knife`);
-      assert.deepEqual(blocked, []);
+      assert.deepEqual(blockedItems, [`he:刀:knife`]);
+    }
+
+    history.push(`💤 1d`, `🟢 he:丿:slash he:𠃌:radical`);
+
+    {
+      const { blockedItems } = await simulateSkillReviews({
+        targetSkills,
+        history,
+      });
+      assert.deepEqual(blockedItems, [`he:刀:knife`]);
+    }
+
+    history.push(`💤 1d`, `🟢 he:丿:slash he:𠃌:radical`);
+
+    {
+      const { blockedItems } = await simulateSkillReviews({
+        targetSkills,
+        history,
+      });
+      assert.deepEqual(blockedItems, [`he:刀:knife`]);
+    }
+
+    history.push(`💤 1d`, `🟢 he:丿:slash he:𠃌:radical`);
+
+    {
+      const { blockedItems } = await simulateSkillReviews({
+        targetSkills,
+        history,
+      });
+      assert.deepEqual(blockedItems, [`he:刀:knife`]);
+    }
+
+    history.push(`💤 1d`, `🟢 he:丿:slash he:𠃌:radical`);
+
+    {
+      const { items, blockedItems } = await simulateSkillReviews({
+        targetSkills,
+        history,
+      });
+      expect(items).toContain(`he:刀:knife`);
+      assert.deepEqual(blockedItems, []);
     }
   });
 
@@ -133,7 +145,7 @@ await test(`${computeSkillReviewQueue.name} suite`, async () => {
     ];
 
     const {
-      available: [review1],
+      items: [review1],
     } = await simulateSkillReviews({ targetSkills, history });
 
     // Doesn't get stuck reviewing he:𠃌:radical just because it had a lower stability.
@@ -153,16 +165,17 @@ await test(`${computeSkillReviewQueue.name} suite`, async () => {
         history,
       });
       expect(queue).toMatchObject({
-        available: [
+        items: [
           `he:刀:knife`,
           // These come later because he:刀:knife is due.
           `he:丿:slash`,
           `he:𠃌:radical`,
         ],
-        blocked: [],
+        blockedItems: [],
         retryCount: 1,
         dueCount: 0,
         overDueCount: 0,
+        newCount: 2,
       });
     }
 
@@ -174,14 +187,15 @@ await test(`${computeSkillReviewQueue.name} suite`, async () => {
         history,
       });
       expect(queue).toMatchObject({
-        available: [`he:丿:slash`, `he:𠃌:radical`],
-        blocked: [
+        items: [`he:丿:slash`, `he:𠃌:radical`],
+        blockedItems: [
           // Now this comes last because it's "stale" and reset to new.
           `he:刀:knife`,
         ],
         retryCount: 0,
         dueCount: 0,
         overDueCount: 0,
+        newCount: 2,
       });
     }
   });

--- a/projects/app/test/data/skills.test.ts
+++ b/projects/app/test/data/skills.test.ts
@@ -318,13 +318,14 @@ await test(`${skillReviewQueue.name} suite`, async () => {
         latestSkillRatings: new Map(),
       }),
     ).toMatchObject({
-      available: [],
-      blocked: [],
-      retryCount: 0,
+      blockedItems: [],
       dueCount: 0,
-      overDueCount: 0,
+      items: [],
+      newCount: 0,
       newDueAt: null,
       newOverDueAt: null,
+      overDueCount: 0,
+      retryCount: 0,
     });
   });
 
@@ -341,11 +342,12 @@ await test(`${skillReviewQueue.name} suite`, async () => {
         latestSkillRatings: new Map(),
       }),
     ).toMatchObject({
-      available: [`he:刀:knife`],
-      blocked: [],
-      retryCount: 0,
+      blockedItems: [],
       dueCount: 1,
+      items: [`he:刀:knife`],
+      newCount: 0,
       overDueCount: 0,
+      retryCount: 0,
     });
   });
 
@@ -362,7 +364,9 @@ await test(`${skillReviewQueue.name} suite`, async () => {
         latestSkillRatings: new Map(),
       }),
     ).toMatchObject({
-      available: [
+      blockedItems: [],
+      dueCount: 1,
+      items: [
         // This would normally be blocked but because it's already introduced
         // (because there's an srs state for it) it's available.
         `he:刀:knife`,
@@ -373,10 +377,9 @@ await test(`${skillReviewQueue.name} suite`, async () => {
         `he:丿:slash`,
         `he:𠃌:radical`,
       ],
-      blocked: [],
-      retryCount: 0,
-      dueCount: 1,
+      newCount: 2,
       overDueCount: 0,
+      retryCount: 0,
     });
   });
 
@@ -392,8 +395,8 @@ await test(`${skillReviewQueue.name} suite`, async () => {
           latestSkillRatings: new Map(),
         }),
       ).toMatchObject({
-        available: [`he:子:child`, `he:女:woman`],
-        blocked: [`he:好:good`],
+        items: [`he:子:child`, `he:女:woman`],
+        blockedItems: [`he:好:good`],
       });
     });
 
@@ -409,8 +412,8 @@ await test(`${skillReviewQueue.name} suite`, async () => {
           latestSkillRatings: new Map(),
         }),
       ).toMatchObject({
-        available: [`he:丿:slash`, `he:亅:hook`, `he:又:again`],
-        blocked: [
+        items: [`he:丿:slash`, `he:亅:hook`, `he:又:again`],
+        blockedItems: [
           `he:水:water`, // learns this because of 氵
           `he:氵:water`,
           `he:汉:chinese`,
@@ -436,14 +439,15 @@ await test(`${skillReviewQueue.name} suite`, async () => {
             ]),
           }),
         ).toMatchObject({
-          available: [
+          blockedItems: [],
+          dueCount: 1,
+          items: [
             `he:丿:slash`, // hoisted to the top for retry
             `he:八:eight`,
           ],
-          blocked: [],
-          retryCount: 1,
-          dueCount: 1,
+          newCount: 0,
           overDueCount: 0,
+          retryCount: 1,
         });
       });
 
@@ -463,11 +467,12 @@ await test(`${skillReviewQueue.name} suite`, async () => {
             ]),
           }),
         ).toMatchObject({
-          available: [`he:八:eight`, `he:丿:slash`],
-          blocked: [],
-          retryCount: 0,
+          blockedItems: [],
           dueCount: 1,
+          items: [`he:八:eight`, `he:丿:slash`],
+          newCount: 1,
           overDueCount: 0,
+          retryCount: 0,
         });
       });
 
@@ -489,11 +494,12 @@ await test(`${skillReviewQueue.name} suite`, async () => {
             ]),
           }),
         ).toMatchObject({
-          available: [`he:八:eight`, `he:丿:slash`],
-          blocked: [],
-          retryCount: 2,
+          blockedItems: [],
           dueCount: 0,
+          items: [`he:八:eight`, `he:丿:slash`],
+          newCount: 0,
           overDueCount: 0,
+          retryCount: 2,
         });
 
         // try in reverse order
@@ -510,11 +516,12 @@ await test(`${skillReviewQueue.name} suite`, async () => {
             ]),
           }),
         ).toMatchObject({
-          available: [`he:丿:slash`, `he:八:eight`],
-          blocked: [],
-          retryCount: 2,
+          blockedItems: [],
           dueCount: 0,
+          items: [`he:丿:slash`, `he:八:eight`],
+          newCount: 0,
           overDueCount: 0,
+          retryCount: 2,
         });
       });
     });
@@ -534,16 +541,12 @@ await test(`${skillReviewQueue.name} suite`, async () => {
           latestSkillRatings: new Map(),
         }),
       ).toMatchObject({
-        available: [
-          `he:八:eight`,
-          `he:刀:knife`,
-          `he:丿:slash`,
-          `he:𠃌:radical`,
-        ],
-        blocked: [`he:分:divide`],
-        retryCount: 0,
+        blockedItems: [`he:分:divide`],
         dueCount: 2,
+        items: [`he:八:eight`, `he:刀:knife`, `he:丿:slash`, `he:𠃌:radical`],
+        newCount: 2,
         overDueCount: 0,
+        retryCount: 0,
       });
     });
 
@@ -559,8 +562,8 @@ await test(`${skillReviewQueue.name} suite`, async () => {
           latestSkillRatings: new Map(),
         }),
       ).toMatchObject({
-        available: [`he:丿:slash`, `he:𠃌:radical`, `he:八:eight`],
-        blocked: [`he:刀:knife`, `he:分:divide`],
+        items: [`he:丿:slash`, `he:𠃌:radical`, `he:八:eight`],
+        blockedItems: [`he:刀:knife`, `he:分:divide`],
       });
     });
 
@@ -581,17 +584,18 @@ await test(`${skillReviewQueue.name} suite`, async () => {
           latestSkillRatings: new Map(),
         }),
       ).toMatchObject({
-        available: [
+        blockedItems: [`he:分:divide`],
+        dueCount: 2,
+        items: [
           `he:一:one`,
           `he:𠃌:radical`,
           `he:丿:slash`,
           `he:刀:knife`,
           `he:八:eight`,
         ],
-        blocked: [`he:分:divide`],
-        retryCount: 0,
-        dueCount: 2,
+        newCount: 1,
         overDueCount: 0,
+        retryCount: 0,
       });
     });
   });
@@ -606,8 +610,8 @@ await test(`${skillReviewQueue.name} suite`, async () => {
           latestSkillRatings: new Map(),
         }),
       ).toMatchObject({
-        available: [`he:子:child`, `he:女:woman`],
-        blocked: [
+        items: [`he:子:child`, `he:女:woman`],
+        blockedItems: [
           `he:好:good`,
           `hpi:好:good`,
           `hpf:好:good`,
@@ -632,13 +636,13 @@ await test(`${skillReviewQueue.name} suite`, async () => {
         skillTypeFromSkill(s) === SkillType.HanziWordToPinyin;
 
       const onlyHpQueue = {
-        available: queue.available.filter((s) => isHpSkill(s)),
-        blocked: queue.blocked.filter((s) => isHpSkill(s)),
+        items: queue.items.filter((s) => isHpSkill(s)),
+        blockedItems: queue.blockedItems.filter((s) => isHpSkill(s)),
       };
 
       assert.deepEqual(onlyHpQueue, {
-        available: [],
-        blocked: [`hp:样:shape`, `hp:一:one`, `hp:一样:same`],
+        items: [],
+        blockedItems: [`hp:样:shape`, `hp:一:one`, `hp:一样:same`],
       });
     });
 
@@ -654,7 +658,7 @@ await test(`${skillReviewQueue.name} suite`, async () => {
           latestSkillRatings: new Map(),
         }),
       ).toMatchObject({
-        available: [
+        items: [
           `he:人:person`,
           `he:八:eight`,
           `he:口:mouth`,
@@ -662,7 +666,7 @@ await test(`${skillReviewQueue.name} suite`, async () => {
           `he:丿:slash`,
           `he:一:one`,
         ],
-        blocked: [
+        blockedItems: [
           `he:火:fire`,
           `he:灬:fire`,
           `he:占:occupy`,
@@ -698,8 +702,8 @@ await test(`${skillReviewQueue.name} suite`, async () => {
           latestSkillRatings: new Map(),
         }),
       ).toMatchObject({
-        available: [`he:一:one`],
-        blocked: [`hpi:一:one`, `hpf:一:one`, `hpt:一:one`, `hp:一:one`],
+        items: [`he:一:one`],
+        blockedItems: [`hpi:一:one`, `hpf:一:one`, `hpt:一:one`, `hp:一:one`],
       });
 
       expect(
@@ -711,11 +715,12 @@ await test(`${skillReviewQueue.name} suite`, async () => {
           latestSkillRatings: new Map(),
         }),
       ).toMatchObject({
-        available: [`he:一:one`, `hpi:一:one`],
-        blocked: [`hpf:一:one`, `hpt:一:one`, `hp:一:one`],
-        retryCount: 0,
+        blockedItems: [`hpf:一:one`, `hpt:一:one`, `hp:一:one`],
         dueCount: 1,
+        items: [`he:一:one`, `hpi:一:one`],
+        newCount: 1,
         overDueCount: 0,
+        retryCount: 0,
       });
 
       expect(
@@ -728,11 +733,12 @@ await test(`${skillReviewQueue.name} suite`, async () => {
           latestSkillRatings: new Map(),
         }),
       ).toMatchObject({
-        available: [`he:一:one`, `hpi:一:one`, `hpf:一:one`],
-        blocked: [`hpt:一:one`, `hp:一:one`],
-        retryCount: 0,
+        blockedItems: [`hpt:一:one`, `hp:一:one`],
         dueCount: 2,
+        items: [`he:一:one`, `hpi:一:one`, `hpf:一:one`],
+        newCount: 1,
         overDueCount: 0,
+        retryCount: 0,
       });
     });
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The queue now displays a count of new items, providing clearer insight into unseen skills.

- **Bug Fixes**
  - Updated UI labels from "available queue" to "queue items" for improved clarity.

- **Refactor**
  - Consolidated multiple queue count props into a single structured object for simpler and more consistent queue statistics handling.

- **Tests**
  - Updated test cases to reflect the new property names and structure for queue items and counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->