### PR TITLE
remove forwardRef

### DIFF
--- a/projects/app/eslint.config.mjs
+++ b/projects/app/eslint.config.mjs
@@ -120,6 +120,11 @@ export default tseslint.config(
               message: `Please use the default \`Animated\` import from \`react-native-reanimated\` instead.`,
             },
             {
+              name: `react`,
+              importNames: [`forwardRef`],
+              message: `Migrate to React 19 patterns.`,
+            },
+            {
               name: `hanzi`,
               message: `Please use @/dictionary/hanzi instead.`,
             },

--- a/projects/app/src/app/(sidenav)/_layout.tsx
+++ b/projects/app/src/app/(sidenav)/_layout.tsx
@@ -5,8 +5,7 @@ import { Link } from "expo-router";
 import type { TabTriggerSlotProps } from "expo-router/ui";
 import { TabList, Tabs, TabSlot, TabTrigger } from "expo-router/ui";
 import { StatusBar } from "expo-status-bar";
-import type { ComponentRef, ReactNode } from "react";
-import { forwardRef } from "react";
+import type { ReactNode } from "react";
 import { Pressable, Text, View } from "react-native";
 import { tv } from "tailwind-variants";
 
@@ -98,32 +97,26 @@ type TabButtonProps = Omit<TabTriggerSlotProps, `children`> & {
   children: ReactNode | ((options: { isFocused: boolean }) => ReactNode);
 };
 
-const TabButton = forwardRef<ComponentRef<typeof Pressable>, TabButtonProps>(
-  (
-    {
-      children,
-      isFocused = false,
-      style, // pull out of `...props` and don't pass to <Pressable>
-      ...props
-    },
-    forwardedRef,
-  ) => (
-    <Pressable {...props} ref={forwardedRef}>
-      {typeof children === `function` ? (
-        children({ isFocused })
-      ) : (
-        <Text
-          className={buttonClass({
-            className: buttonTextClass({ isFocused }),
-          })}
-        >
-          {children}
-        </Text>
-      )}
-    </Pressable>
-  ),
+const TabButton = ({
+  children,
+  isFocused = false,
+  style, // pull out of `...props` and don't pass to <Pressable>
+  ...props
+}: TabButtonProps) => (
+  <Pressable {...props}>
+    {typeof children === `function` ? (
+      children({ isFocused })
+    ) : (
+      <Text
+        className={buttonClass({
+          className: buttonTextClass({ isFocused }),
+        })}
+      >
+        {children}
+      </Text>
+    )}
+  </Pressable>
 );
-TabButton.displayName = `TabButton`;
 
 const iconClass = tv({
   base: `size-[24px] flex-shrink`,

--- a/projects/app/src/client/ui/CircleButton.tsx
+++ b/projects/app/src/client/ui/CircleButton.tsx
@@ -1,7 +1,6 @@
 import Color from "color";
 import { Image } from "expo-image";
-import type { ComponentRef } from "react";
-import { forwardRef, useMemo } from "react";
+import { useMemo } from "react";
 import type { ColorValue } from "react-native";
 import { Pressable, View } from "react-native";
 import { hapticImpactIfMobile } from "../hooks/hapticImpactIfMobile";
@@ -14,19 +13,13 @@ export type CircleButtonProps = {
   color?: ColorValue;
 } & PropsOf<typeof Pressable>;
 
-export const CircleButton = forwardRef<
-  ComponentRef<typeof Pressable>,
-  CircleButtonProps
->(function CircleButton(
-  {
-    thickness = 10,
-    scaleY = 0.8,
-    diameter = 80,
-    color = `#1CB0F5`,
-    ...pressableProps
-  },
-  ref,
-) {
+export function CircleButton({
+  thickness = 10,
+  scaleY = 0.8,
+  diameter = 80,
+  color = `#1CB0F5`,
+  ...pressableProps
+}: CircleButtonProps) {
   const baseColor = useMemo(() => Color(color).darken(0.2).hex(), [color]);
 
   return (
@@ -36,7 +29,6 @@ export const CircleButton = forwardRef<
         hapticImpactIfMobile();
         pressableProps.onPressIn?.(e);
       }}
-      ref={ref}
     >
       {({ pressed }) => (
         <View
@@ -106,4 +98,4 @@ export const CircleButton = forwardRef<
       )}
     </Pressable>
   );
-});
+}

--- a/projects/app/src/client/ui/QuizDeckMultipleChoiceQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckMultipleChoiceQuestion.tsx
@@ -5,8 +5,7 @@ import type {
 } from "@/data/model";
 import { setAudioModeAsync, useAudioPlayer } from "expo-audio";
 import chunk from "lodash/chunk";
-import type { ComponentRef } from "react";
-import { forwardRef, memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useState } from "react";
 import { Text, View } from "react-native";
 import { RectButton } from "./RectButton";
 import type { PropsOf } from "./types";
@@ -89,10 +88,14 @@ export const QuizDeckMultipleChoiceQuestion = memo(
   },
 );
 
-const SubmitButton = forwardRef<
-  ComponentRef<typeof RectButton>,
-  { disabled: boolean } & Pick<PropsOf<typeof RectButton>, `onPress`>
->(function SubmitButton({ disabled, ...rectButtonProps }, ref) {
+function SubmitButton({
+  disabled,
+  ref,
+  ...rectButtonProps
+}: { disabled: boolean } & Pick<
+  PropsOf<typeof RectButton>,
+  `onPress` | `ref`
+>) {
   const color = disabled ? `#3A464E` : `#A1D151`;
   const textColor = disabled ? `#56646C` : `#161F23`;
 
@@ -118,7 +121,7 @@ const SubmitButton = forwardRef<
       </Text>
     </RectButton>
   );
-});
+}
 
 const AnswerButton = ({
   selected,

--- a/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
@@ -19,15 +19,8 @@ import { invariant } from "@haohaohow/lib/invariant";
 import { formatDuration } from "date-fns/formatDuration";
 import { intervalToDuration } from "date-fns/intervalToDuration";
 import { Image } from "expo-image";
-import type { ComponentRef, ReactNode } from "react";
-import {
-  forwardRef,
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import type { ReactNode } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { StyleProp, ViewStyle } from "react-native";
 import {
   // eslint-disable-next-line @typescript-eslint/no-restricted-imports
@@ -534,10 +527,13 @@ enum SubmitButtonState {
   Incorrect,
 }
 
-const SubmitButton = forwardRef<
-  ComponentRef<typeof RectButton2>,
-  { state: SubmitButtonState } & Pick<PropsOf<typeof RectButton2>, `onPress`>
->(function SubmitButton({ state, onPress }, ref) {
+function SubmitButton({
+  state,
+  onPress,
+  ref,
+}: {
+  state: SubmitButtonState;
+} & Pick<PropsOf<typeof RectButton2>, `onPress` | `ref`>) {
   let text;
 
   switch (state) {
@@ -567,7 +563,7 @@ const SubmitButton = forwardRef<
       {text}
     </RectButton2>
   );
-});
+}
 
 const ChoiceButton = ({
   state,

--- a/projects/app/src/client/ui/RectButton.tsx
+++ b/projects/app/src/client/ui/RectButton.tsx
@@ -1,6 +1,5 @@
 import Color from "color";
-import type { ComponentRef } from "react";
-import { forwardRef, useMemo } from "react";
+import { useMemo } from "react";
 import type { ColorValue, ViewProps } from "react-native";
 import { Pressable, View } from "react-native";
 import { hapticImpactIfMobile } from "../hooks/hapticImpactIfMobile";
@@ -15,21 +14,15 @@ export type RectButtonProps = {
   children?: ViewProps[`children`];
 } & Omit<PropsOf<typeof Pressable>, `children`>;
 
-export const RectButton = forwardRef<
-  ComponentRef<typeof Pressable>,
-  RectButtonProps
->(function RectButton(
-  {
-    thickness = 4,
-    borderRadius = 16,
-    borderWidth = 0,
-    color = `#1CB0F5`,
-    accentColor,
-    children,
-    ...pressableProps
-  },
-  ref,
-) {
+export function RectButton({
+  thickness = 4,
+  borderRadius = 16,
+  borderWidth = 0,
+  color = `#1CB0F5`,
+  accentColor,
+  children,
+  ...pressableProps
+}: RectButtonProps) {
   accentColor = useMemo(
     () => accentColor ?? Color(color).darken(0.2).hex(),
     [accentColor, color],
@@ -46,7 +39,6 @@ export const RectButton = forwardRef<
         hapticImpactIfMobile();
         pressableProps.onPressIn?.(e);
       }}
-      ref={ref}
     >
       {({ pressed }) => (
         <View
@@ -94,4 +86,4 @@ export const RectButton = forwardRef<
       )}
     </Pressable>
   );
-});
+}

--- a/projects/app/src/client/ui/RectButton2.tsx
+++ b/projects/app/src/client/ui/RectButton2.tsx
@@ -1,5 +1,4 @@
-import type { ComponentRef } from "react";
-import { forwardRef, useState } from "react";
+import { useState } from "react";
 import type { ViewProps } from "react-native";
 import { Pressable, Text, View } from "react-native";
 import { tv } from "tailwind-variants";
@@ -16,23 +15,17 @@ export type RectButton2Props = {
   textClassName?: string;
 } & Pick<
   PropsOf<typeof Pressable>,
-  keyof PropsOf<typeof Pressable> & (`on${string}` | `disabled`)
+  keyof PropsOf<typeof Pressable> & (`on${string}` | `disabled` | `ref`)
 >;
 
-export const RectButton2 = forwardRef<
-  ComponentRef<typeof Pressable>,
-  RectButton2Props
->(function RectButton2(
-  {
-    children,
-    variant = `outline`,
-    className,
-    inFlexRowParent = false,
-    textClassName,
-    ...pressableProps
-  },
-  ref,
-) {
+export function RectButton2({
+  children,
+  variant = `outline`,
+  className,
+  inFlexRowParent = false,
+  textClassName,
+  ...pressableProps
+}: RectButton2Props) {
   const disabled = pressableProps.disabled === true;
 
   const [pressed, setPressed] = useState(false);
@@ -60,7 +53,6 @@ export const RectButton2 = forwardRef<
         setPressed(false);
         pressableProps.onPressOut?.(e);
       }}
-      ref={ref}
       className={pressable({ flat, variant, inFlexRowParent, className })}
     >
       <View
@@ -82,7 +74,7 @@ export const RectButton2 = forwardRef<
       </View>
     </Pressable>
   );
-});
+}
 
 const pressable = tv({
   base: `web:transition-all`,

--- a/projects/app/src/client/ui/TextAnswerButton.tsx
+++ b/projects/app/src/client/ui/TextAnswerButton.tsx
@@ -1,6 +1,5 @@
 import { characterCount } from "@/dictionary/dictionary";
-import type { ComponentRef } from "react";
-import { forwardRef, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { Pressable } from "react-native";
 import { Text, View } from "react-native";
 import Reanimated, {
@@ -35,21 +34,15 @@ export type TextAnswerButtonProps = {
   disabled?: boolean;
 } & Omit<PropsOf<typeof Pressable>, `children` | `disabled`>;
 
-export const TextAnswerButton = forwardRef<
-  ComponentRef<typeof Pressable>,
-  TextAnswerButtonProps
->(function TextAnswerButton(
-  {
-    disabled = false,
-    text,
-    state = `default`,
-    inFlexRowParent = false,
-    className,
-    textClassName,
-    ...pressableProps
-  },
-  ref,
-) {
+export function TextAnswerButton({
+  disabled = false,
+  text,
+  state = `default`,
+  inFlexRowParent = false,
+  className,
+  textClassName,
+  ...pressableProps
+}: TextAnswerButtonProps) {
   const [prevState, setPrevState] = useState(state);
   const [bgFilled, setBgFilled] = useState(false);
   const [pressed, setPressed] = useState(false);
@@ -160,7 +153,6 @@ export const TextAnswerButton = forwardRef<
       onPress={(e) => {
         pressableProps.onPress?.(e);
       }}
-      ref={ref}
       style={pressableAnimatedStyle}
       className={containerClass({ flat, state, inFlexRowParent, className })}
     >
@@ -193,7 +185,7 @@ export const TextAnswerButton = forwardRef<
       </View>
     </AnimatedPressable>
   );
-});
+}
 
 const duration = 100;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated several button components to remove React’s `forwardRef` usage, simplifying component signatures and ref handling.
- **Chores**
  - Added a restriction to prevent importing `forwardRef` from React, aligning with new React 19 patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->