### PR TITLE
naming convention

### DIFF
--- a/docs/code-conventions.md
+++ b/docs/code-conventions.md
@@ -1,0 +1,30 @@
+# Code Conventions
+
+This document outlines code conventions for this codebase. These conventions are intended to guide AI coding agents and human contributors to write code that is consistent, maintainable, and aligned with existing styles.
+
+## Discriminated Unions in TypeScript
+
+- **Use `kind` as the discriminator property**  
+   When defining discriminated unions in TypeScript, always use a property named `kind` rather than `type`.
+  - This avoids naming conflicts, since interfaces and types are often suffixed with `Type` to prevent clashes with React components.
+  - The discriminator's type should be suffixed with `Kind` (e.g., `FooKind`), ensuring clear and conflict-free naming.
+
+**Example:**
+
+```typescript
+export type ShapeKind = "circle" | "square";
+
+export interface CircleType {
+  kind: "circle";
+  radius: number;
+}
+
+export interface SquareType {
+  kind: "square";
+  side: number;
+}
+
+export type ShapeType = CircleType | SquareType;
+```
+
+## [Add further conventions below as needed]

--- a/docs/skill-kinds.md
+++ b/docs/skill-kinds.md
@@ -1,8 +1,8 @@
-# Skill Types in haohaohow
+# Skill kinds in haohaohow
 
 This document describes the different types of skills available in haohaohow.
 
-## Skill Types
+## Skill kinds
 
 - **RadicalToEnglish (`re`)**: Translate a radical to English.
 - **EnglishToRadical (`er`)**: Translate English to a radical.

--- a/projects/app/bin/generateHanziDecomposition.ts
+++ b/projects/app/bin/generateHanziDecomposition.ts
@@ -181,7 +181,7 @@ for (const character of decompositionQueue) {
   for (const decomposition of decompositions) {
     let score = decomposition.tags.has(SourceTag.China) ? 100 : 0;
     for (const leaf of walkIdsNode(decomposition.idsNode)) {
-      switch (leaf.type) {
+      switch (leaf.operator) {
         case `LeafCharacter`: {
           score -= allDecompositions.has(leaf.character) ? 1 : 3;
           break;
@@ -241,7 +241,7 @@ for (const character of decompositionQueue) {
 
   for (const decomposition of bestDecompositions) {
     for (const leaf of walkIdsNode(decomposition.idsNode)) {
-      if (leaf.type === `LeafCharacter`) {
+      if (leaf.operator === `LeafCharacter`) {
         decompositionQueue.add(leaf.character);
       }
     }

--- a/projects/app/bin/generateMissingFontGlyphs.ts
+++ b/projects/app/bin/generateMissingFontGlyphs.ts
@@ -46,7 +46,7 @@ for (const char of allChars) {
   );
   const idsNode = parseIds(ids);
   for (const leaf of walkIdsNode(idsNode)) {
-    if (leaf.type === `LeafCharacter`) {
+    if (leaf.operator === `LeafCharacter`) {
       allComponents.add(leaf.character);
     }
   }

--- a/projects/app/bin/generateWordDictionary.tsx
+++ b/projects/app/bin/generateWordDictionary.tsx
@@ -133,7 +133,7 @@ function decomp(char: string) {
   if (ids != null) {
     const idsNode = parseIds(ids);
     for (const leaf of walkIdsNode(idsNode)) {
-      if (leaf.type === `LeafCharacter` && leaf.character !== char) {
+      if (leaf.operator === `LeafCharacter` && leaf.character !== char) {
         decomp(leaf.character);
       }
     }
@@ -195,7 +195,7 @@ async function checkHsk1HanziWords(
     }
 
     const json = await openai(
-      [`curriculum.md`, `word-representation.md`, `skill-types.md`],
+      [`curriculum.md`, `word-representation.md`, `skill-kinds.md`],
       `
 Can you check my word list for HSK1 and make sure it's correct. I need to know if the gloss I have for each word is correct.
 
@@ -579,7 +579,7 @@ const HanziEditor = ({
                     [
                       `curriculum.md`,
                       `word-representation.md`,
-                      `skill-types.md`,
+                      `skill-kinds.md`,
                     ],
                     `
 I want to create a new HanziWord entry for ${hanzi} based on the gloss: ${query}
@@ -659,7 +659,7 @@ async function openAiHanziWordGlossHintQuery(
       hanziIds = hanziIds.replaceAll(char, ids);
 
       for (const leaf of walkIdsNode(parseIds(ids))) {
-        switch (leaf.type) {
+        switch (leaf.operator) {
           case `LeafUnknownCharacter`: {
             mapSetAdd(
               componentGlosses,
@@ -1661,7 +1661,7 @@ interface GenerateHanziWordQuery {
 
 async function queryOpenAiForHanziWordResults(query: unknown) {
   const { suggestions } = await openai(
-    [`curriculum.md`, `word-representation.md`, `skill-types.md`],
+    [`curriculum.md`, `word-representation.md`, `skill-kinds.md`],
     `
 I have a hanzi I want to add to a word list, can fill in the rest of the data for me?
 

--- a/projects/app/src/app/(sidenav)/learn/history/index.tsx
+++ b/projects/app/src/app/(sidenav)/learn/history/index.tsx
@@ -3,8 +3,8 @@ import { useRizzleQueryPaged } from "@/client/ui/ReplicacheContext";
 import { SkillRefText } from "@/client/ui/SkillRefText";
 import {
   needsToBeIntroduced,
-  skillTypeFromSkill,
-  skillTypeToShorthand,
+  skillKindFromSkill,
+  skillKindToShorthand,
 } from "@/data/skills";
 import {
   emptyArray,
@@ -112,7 +112,7 @@ export default function HistoryPage() {
               <View key={i} className="flex-col items-center">
                 <SkillRefText skill={skill} context="body" />
                 <Text className="hhh-text-caption">
-                  {skillTypeToShorthand(skillTypeFromSkill(skill))}
+                  {skillKindToShorthand(skillKindFromSkill(skill))}
                 </Text>
               </View>
             ))}

--- a/projects/app/src/app/(sidenav)/learn/index.tsx
+++ b/projects/app/src/app/(sidenav)/learn/index.tsx
@@ -3,9 +3,9 @@ import { Countdown } from "@/client/ui/Countdown";
 import { RectButton2 } from "@/client/ui/RectButton2";
 import { useRizzleQueryPaged } from "@/client/ui/ReplicacheContext";
 import type { HanziWord } from "@/data/model";
-import { SkillType } from "@/data/model";
+import { SkillKind } from "@/data/model";
 import type { HanziWordSkill } from "@/data/rizzleSchema";
-import { hanziWordFromSkill, skillTypeFromSkill } from "@/data/skills";
+import { hanziWordFromSkill, skillKindFromSkill } from "@/data/skills";
 import { hanziFromHanziWord } from "@/dictionary/dictionary";
 import { invariant } from "@haohaohow/lib/invariant";
 import { differenceInCalendarDays } from "date-fns/differenceInCalendarDays";
@@ -39,15 +39,15 @@ export default function IndexPage() {
         .toArray()
         .then((x) => x.reverse());
       pushLoop: for (let [, { skill }] of ratingHistory) {
-        switch (skillTypeFromSkill(skill)) {
-          case SkillType.GlossToHanziWord:
-          case SkillType.HanziWordToGloss:
-          case SkillType.HanziWordToPinyin:
-          case SkillType.HanziWordToPinyinFinal:
-          case SkillType.HanziWordToPinyinInitial:
-          case SkillType.HanziWordToPinyinTone:
-          case SkillType.ImageToHanziWord:
-          case SkillType.PinyinToHanziWord: {
+        switch (skillKindFromSkill(skill)) {
+          case SkillKind.GlossToHanziWord:
+          case SkillKind.HanziWordToGloss:
+          case SkillKind.HanziWordToPinyin:
+          case SkillKind.HanziWordToPinyinFinal:
+          case SkillKind.HanziWordToPinyinInitial:
+          case SkillKind.HanziWordToPinyinTone:
+          case SkillKind.ImageToHanziWord:
+          case SkillKind.PinyinToHanziWord: {
             skill = skill as HanziWordSkill;
             const hanziWord = hanziWordFromSkill(skill);
             if (!recentHanziWords.includes(hanziWord)) {
@@ -59,13 +59,13 @@ export default function IndexPage() {
             break;
           }
 
-          case SkillType.Deprecated_EnglishToRadical:
-          case SkillType.Deprecated_PinyinToRadical:
-          case SkillType.Deprecated_RadicalToEnglish:
-          case SkillType.Deprecated_RadicalToPinyin:
-          case SkillType.Deprecated:
-          case SkillType.PinyinFinalAssociation:
-          case SkillType.PinyinInitialAssociation: {
+          case SkillKind.Deprecated_EnglishToRadical:
+          case SkillKind.Deprecated_PinyinToRadical:
+          case SkillKind.Deprecated_RadicalToEnglish:
+          case SkillKind.Deprecated_RadicalToPinyin:
+          case SkillKind.Deprecated:
+          case SkillKind.PinyinFinalAssociation:
+          case SkillKind.PinyinInitialAssociation: {
             break;
           }
         }

--- a/projects/app/src/app/dev/ui.tsx
+++ b/projects/app/src/app/dev/ui.tsx
@@ -1,6 +1,8 @@
+/* eslint-disable no-console */
 import { useQuizProgress } from "@/client/hooks/useQuizProgress";
 import { HanziText } from "@/client/ui/HanziText";
 import { PinyinOptionButton } from "@/client/ui/PinyinOptionButton";
+import { QuizDeckHanziToPinyinQuestion } from "@/client/ui/QuizDeckHanziToPinyinQuestion";
 import { QuizProgressBar } from "@/client/ui/QuizProgressBar";
 import { QuizQueueButton } from "@/client/ui/QuizQueueButton";
 import { RectButton2 } from "@/client/ui/RectButton2";
@@ -8,6 +10,10 @@ import type { TextAnswerButtonState } from "@/client/ui/TextAnswerButton";
 import { TextAnswerButton } from "@/client/ui/TextAnswerButton";
 import { TextInputSingle } from "@/client/ui/TextInputSingle";
 import type { PropsOf } from "@/client/ui/types";
+import type { HanziChar } from "@/data/model";
+import { QuestionKind } from "@/data/model";
+import { hanziWordToPinyin } from "@/data/skills";
+import { buildHanziWord } from "@/dictionary/dictionary";
 import { Link } from "expo-router";
 import shuffle from "lodash/shuffle";
 import type { ReactNode } from "react";
@@ -32,6 +38,13 @@ export default function DesignSystemPage() {
         </Link>
       </View>
       <ScrollView style={{ flex: 1 }} ref={scrollViewRef}>
+        <Section
+          title={QuizDeckHanziToPinyinQuestionExample.name}
+          scrollTo={scrollTo}
+        >
+          <QuizDeckHanziToPinyinQuestionExample />
+        </Section>
+
         <Section title={PinyinOptionButtonExample.name} scrollTo={scrollTo}>
           <PinyinOptionButtonExample />
         </Section>
@@ -909,5 +922,26 @@ function PinyinOptionButtonExample() {
         <PinyinOptionButton text="ni" shortcutKey="5" disabled />
       </ExampleStack>
     </View>
+  );
+}
+function QuizDeckHanziToPinyinQuestionExample() {
+  return (
+    <QuizDeckHanziToPinyinQuestion
+      question={{
+        kind: QuestionKind.HanziToPinyin,
+        prompt: `Prompt text`,
+        answer: [
+          [`你` as HanziChar, `nǐ`],
+          [`好` as HanziChar, `hǎo`],
+        ],
+        skill: hanziWordToPinyin(buildHanziWord(`你好`, `hello`)),
+      }}
+      onNext={() => {
+        console.log(`onNext()`);
+      }}
+      onRating={() => {
+        console.log(`onRating()`);
+      }}
+    />
   );
 }

--- a/projects/app/src/client/query.ts
+++ b/projects/app/src/client/query.ts
@@ -1,6 +1,6 @@
 import { generateQuestionForSkillOrThrow } from "@/data/generator";
-import type { Question, QuestionFlag, SrsState } from "@/data/model";
-import { QuestionFlagType, SrsType } from "@/data/model";
+import type { Question, QuestionFlagType, SrsStateType } from "@/data/model";
+import { QuestionFlagKind, SrsKind } from "@/data/model";
 import type { Rizzle, Skill, SkillRating } from "@/data/rizzleSchema";
 import type { SkillReviewQueue } from "@/data/skills";
 import {
@@ -34,7 +34,7 @@ export async function questionsForReview2(
       const isRetry = reviewQueue.retryCount > 0 && i < reviewQueue.retryCount;
       if (isRetry) {
         question.flag ??= {
-          type: QuestionFlagType.Retry,
+          kind: QuestionFlagKind.Retry,
         };
       }
       question.flag ??= flagsForSrsState(skillState?.srs);
@@ -56,14 +56,14 @@ export async function questionsForReview2(
 }
 
 export function flagsForSrsState(
-  srsState: SrsState | undefined,
-): QuestionFlag | undefined {
+  srsState: SrsStateType | undefined,
+): QuestionFlagType | undefined {
   if (
-    srsState?.type !== SrsType.FsrsFourPointFive ||
+    srsState?.kind !== SrsKind.FsrsFourPointFive ||
     fsrsIsForgotten(srsState)
   ) {
     return {
-      type: QuestionFlagType.NewSkill,
+      kind: QuestionFlagKind.NewSkill,
     };
   }
   const now = new Date();
@@ -71,7 +71,7 @@ export function flagsForSrsState(
 
   if (now >= overDueDate) {
     return {
-      type: QuestionFlagType.Overdue,
+      kind: QuestionFlagKind.Overdue,
       interval: interval(overDueDate.getTime(), now),
     };
   }
@@ -106,7 +106,7 @@ export async function computeSkillReviewQueue(
 ): Promise<SkillReviewQueue> {
   const graph = await skillLearningGraph({ targetSkills });
 
-  const skillSrsStates = new Map<Skill, SrsState>();
+  const skillSrsStates = new Map<Skill, SrsStateType>();
   for await (const [, v] of r.queryPaged.skillState.scan()) {
     skillSrsStates.set(v.skill, v.srs);
   }

--- a/projects/app/src/client/ui/NewSkillModal.tsx
+++ b/projects/app/src/client/ui/NewSkillModal.tsx
@@ -1,8 +1,8 @@
 import { useHanziWordMeaning } from "@/client/hooks/useHanziWordMeaning";
 import { splitHanziText } from "@/data/hanzi";
-import { SkillType } from "@/data/model";
+import { SkillKind } from "@/data/model";
 import type { HanziWordSkill, Skill } from "@/data/rizzleSchema";
-import { hanziWordFromSkill, skillTypeFromSkill } from "@/data/skills";
+import { hanziWordFromSkill, skillKindFromSkill } from "@/data/skills";
 import { hanziFromHanziWord } from "@/dictionary/dictionary";
 import { Image } from "expo-image";
 import { useMemo, useState } from "react";
@@ -29,8 +29,8 @@ export const NewSkillModal = ({
       passivePresentation={passivePresentation}
     >
       {({ dismiss }) => {
-        switch (skillTypeFromSkill(skill)) {
-          case SkillType.HanziWordToGloss: {
+        switch (skillKindFromSkill(skill)) {
+          case SkillKind.HanziWordToGloss: {
             skill = skill as HanziWordSkill;
             return (
               <NewHanziWordToGlossSkillContent
@@ -39,7 +39,7 @@ export const NewSkillModal = ({
               />
             );
           }
-          case SkillType.HanziWordToPinyin: {
+          case SkillKind.HanziWordToPinyin: {
             skill = skill as HanziWordSkill;
             return (
               <NewHanziWordToPinyinSkillContent
@@ -48,7 +48,7 @@ export const NewSkillModal = ({
               />
             );
           }
-          case SkillType.HanziWordToPinyinFinal: {
+          case SkillKind.HanziWordToPinyinFinal: {
             skill = skill as HanziWordSkill;
             return (
               <NewHanziWordToPinyinFinalSkillContent
@@ -57,7 +57,7 @@ export const NewSkillModal = ({
               />
             );
           }
-          case SkillType.HanziWordToPinyinInitial: {
+          case SkillKind.HanziWordToPinyinInitial: {
             skill = skill as HanziWordSkill;
             return (
               <NewHanziWordToPinyinInitialSkillContent
@@ -66,7 +66,7 @@ export const NewSkillModal = ({
               />
             );
           }
-          case SkillType.HanziWordToPinyinTone: {
+          case SkillKind.HanziWordToPinyinTone: {
             skill = skill as HanziWordSkill;
             return (
               <NewHanziWordToPinyinToneSkillContent
@@ -75,16 +75,16 @@ export const NewSkillModal = ({
               />
             );
           }
-          case SkillType.Deprecated_EnglishToRadical:
-          case SkillType.Deprecated_PinyinToRadical:
-          case SkillType.Deprecated_RadicalToEnglish:
-          case SkillType.Deprecated_RadicalToPinyin:
-          case SkillType.Deprecated:
-          case SkillType.GlossToHanziWord:
-          case SkillType.ImageToHanziWord:
-          case SkillType.PinyinFinalAssociation:
-          case SkillType.PinyinInitialAssociation:
-          case SkillType.PinyinToHanziWord: {
+          case SkillKind.Deprecated_EnglishToRadical:
+          case SkillKind.Deprecated_PinyinToRadical:
+          case SkillKind.Deprecated_RadicalToEnglish:
+          case SkillKind.Deprecated_RadicalToPinyin:
+          case SkillKind.Deprecated:
+          case SkillKind.GlossToHanziWord:
+          case SkillKind.ImageToHanziWord:
+          case SkillKind.PinyinFinalAssociation:
+          case SkillKind.PinyinInitialAssociation:
+          case SkillKind.PinyinToHanziWord: {
             return (
               <ContainerWithContinueButton onContinue={dismiss}>
                 <Text>Not implemented</Text>

--- a/projects/app/src/client/ui/QuizDeckMultipleChoiceQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckMultipleChoiceQuestion.tsx
@@ -1,5 +1,5 @@
 import type {
-  Mistake,
+  MistakeType,
   MultipleChoiceQuestion,
   NewSkillRating,
 } from "@/data/model";
@@ -19,7 +19,7 @@ export function QuizDeckMultipleChoiceQuestion({
 }: {
   question: MultipleChoiceQuestion;
   onNext: () => void;
-  onRating: (ratings: NewSkillRating[], mistakes: Mistake[]) => void;
+  onRating: (ratings: NewSkillRating[], mistakes: MistakeType[]) => void;
 }) {
   const { prompt, choices } = question;
   const [selectedChoice, setSelectedChoice] = useState<string>();

--- a/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckOneCorrectPairQuestion.tsx
@@ -1,19 +1,19 @@
 import { useHanziWordMeaning } from "@/client/hooks/useHanziWordMeaning";
 import { useMultiChoiceQuizTimer } from "@/client/hooks/useMultiChoiceQuizTimer";
 import type {
-  Mistake,
+  MistakeType,
   NewSkillRating,
   OneCorrectPairQuestion,
   OneCorrectPairQuestionChoice,
-  QuestionFlag,
+  QuestionFlagType,
 } from "@/data/model";
-import { QuestionFlagType, SkillType } from "@/data/model";
+import { QuestionFlagKind, SkillKind } from "@/data/model";
 import type { HanziWordSkill, Skill } from "@/data/rizzleSchema";
 import {
   computeSkillRating,
   hanziWordFromSkill,
   oneCorrectPairQuestionChoiceMistakes,
-  skillTypeFromSkill,
+  skillKindFromSkill,
 } from "@/data/skills";
 import { invariant } from "@haohaohow/lib/invariant";
 import { formatDuration } from "date-fns/formatDuration";
@@ -51,7 +51,7 @@ export function QuizDeckOneCorrectPairQuestion({
 }: {
   question: OneCorrectPairQuestion;
   onNext: () => void;
-  onRating: (ratings: NewSkillRating[], mistakes: Mistake[]) => void;
+  onRating: (ratings: NewSkillRating[], mistakes: MistakeType[]) => void;
 }) {
   const { prompt, answer, groupA, groupB, flag } = question;
 
@@ -191,7 +191,7 @@ export function QuizDeckOneCorrectPairQuestion({
         />
       }
     >
-      {flag?.type === QuestionFlagType.NewSkill ? (
+      {flag?.kind === QuestionFlagKind.NewSkill ? (
         <NewSkillModal passivePresentation skill={question.answer.skill} />
       ) : null}
 
@@ -262,9 +262,9 @@ export function QuizDeckOneCorrectPairQuestion({
   );
 }
 
-const FlagText = ({ flag }: { flag: QuestionFlag }) => {
-  switch (flag.type) {
-    case QuestionFlagType.NewSkill: {
+const FlagText = ({ flag }: { flag: QuestionFlagType }) => {
+  switch (flag.kind) {
+    case QuestionFlagKind.NewSkill: {
       return (
         <View className={flagViewClass({ class: `success-theme` })}>
           <Image
@@ -276,7 +276,7 @@ const FlagText = ({ flag }: { flag: QuestionFlag }) => {
         </View>
       );
     }
-    case QuestionFlagType.Overdue: {
+    case QuestionFlagKind.Overdue: {
       return (
         <View className={flagViewClass({ class: `danger-theme` })}>
           <Image
@@ -304,7 +304,7 @@ const FlagText = ({ flag }: { flag: QuestionFlag }) => {
         </View>
       );
     }
-    case QuestionFlagType.Retry: {
+    case QuestionFlagKind.Retry: {
       return (
         <View className={flagViewClass({ class: `warning-theme` })}>
           <Image
@@ -316,7 +316,7 @@ const FlagText = ({ flag }: { flag: QuestionFlag }) => {
         </View>
       );
     }
-    case QuestionFlagType.WeakWord: {
+    case QuestionFlagKind.WeakWord: {
       return (
         <View className={flagViewClass({ class: `danger-theme` })}>
           <Image
@@ -344,7 +344,7 @@ const flagTextClass = tv({
 });
 
 function choiceToHhhmark(choice: OneCorrectPairQuestionChoice): string {
-  switch (choice.type) {
+  switch (choice.kind) {
     case `gloss`: {
       return `**${choice.value}**`;
     }
@@ -370,31 +370,31 @@ const SkillAnswer = ({
   hideB?: boolean;
   small?: boolean;
 }) => {
-  switch (skillTypeFromSkill(skill)) {
-    case SkillType.Deprecated_EnglishToRadical:
-    case SkillType.Deprecated_PinyinToRadical:
-    case SkillType.Deprecated_RadicalToEnglish:
-    case SkillType.Deprecated_RadicalToPinyin:
-    case SkillType.Deprecated:
-    case SkillType.GlossToHanziWord:
-    case SkillType.ImageToHanziWord:
-    case SkillType.PinyinFinalAssociation:
-    case SkillType.PinyinInitialAssociation:
-    case SkillType.PinyinToHanziWord: {
+  switch (skillKindFromSkill(skill)) {
+    case SkillKind.Deprecated_EnglishToRadical:
+    case SkillKind.Deprecated_PinyinToRadical:
+    case SkillKind.Deprecated_RadicalToEnglish:
+    case SkillKind.Deprecated_RadicalToPinyin:
+    case SkillKind.Deprecated:
+    case SkillKind.GlossToHanziWord:
+    case SkillKind.ImageToHanziWord:
+    case SkillKind.PinyinFinalAssociation:
+    case SkillKind.PinyinInitialAssociation:
+    case SkillKind.PinyinToHanziWord: {
       throw new Error(
-        `ShowSkillAnswer not implemented for ${skillTypeFromSkill(skill)}`,
+        `ShowSkillAnswer not implemented for ${skillKindFromSkill(skill)}`,
       );
     }
-    case SkillType.HanziWordToGloss: {
+    case SkillKind.HanziWordToGloss: {
       skill = skill as HanziWordSkill;
       return (
         <HanziWordToGlossSkillAnswer skill={skill} includeHint={includeHint} />
       );
     }
-    case SkillType.HanziWordToPinyin:
-    case SkillType.HanziWordToPinyinFinal:
-    case SkillType.HanziWordToPinyinInitial:
-    case SkillType.HanziWordToPinyinTone: {
+    case SkillKind.HanziWordToPinyin:
+    case SkillKind.HanziWordToPinyinFinal:
+    case SkillKind.HanziWordToPinyinInitial:
+    case SkillKind.HanziWordToPinyinTone: {
       skill = skill as HanziWordSkill;
       return <HanziWordToPinyinSkillAnswer skill={skill} />;
     }

--- a/projects/app/src/client/ui/SkillRefText.tsx
+++ b/projects/app/src/client/ui/SkillRefText.tsx
@@ -1,4 +1,4 @@
-import { SkillType } from "@/data/model";
+import { SkillKind } from "@/data/model";
 import type {
   DeprecatedSkill,
   HanziWordSkill,
@@ -10,8 +10,8 @@ import {
   finalFromPinyinFinalAssociationSkill,
   hanziWordFromSkill,
   initialFromPinyinInitialAssociationSkill,
-  skillTypeFromSkill,
-  skillTypeToShorthand,
+  skillKindFromSkill,
+  skillKindToShorthand,
 } from "@/data/skills";
 import { Text } from "react-native";
 import { HanziWordRefText } from "./HanziWordRefText";
@@ -24,24 +24,24 @@ export const SkillRefText = ({
   skill: Skill;
   context: HhhmarkContext;
 }) => {
-  switch (skillTypeFromSkill(skill)) {
-    case SkillType.PinyinFinalAssociation: {
+  switch (skillKindFromSkill(skill)) {
+    case SkillKind.PinyinFinalAssociation: {
       skill = skill as PinyinFinalAssociationSkill;
       return <Text>-{finalFromPinyinFinalAssociationSkill(skill)}</Text>;
     }
-    case SkillType.PinyinInitialAssociation: {
+    case SkillKind.PinyinInitialAssociation: {
       skill = skill as PinyinInitialAssociationSkill;
       return <Text>{initialFromPinyinInitialAssociationSkill(skill)}-</Text>;
     }
-    case SkillType.Deprecated_RadicalToEnglish:
-    case SkillType.Deprecated_EnglishToRadical:
-    case SkillType.Deprecated_RadicalToPinyin:
-    case SkillType.Deprecated_PinyinToRadical:
-    case SkillType.Deprecated: {
+    case SkillKind.Deprecated_RadicalToEnglish:
+    case SkillKind.Deprecated_EnglishToRadical:
+    case SkillKind.Deprecated_RadicalToPinyin:
+    case SkillKind.Deprecated_PinyinToRadical:
+    case SkillKind.Deprecated: {
       skill = skill as DeprecatedSkill;
-      return <Text>{skillTypeToShorthand(skillTypeFromSkill(skill))}</Text>;
+      return <Text>{skillKindToShorthand(skillKindFromSkill(skill))}</Text>;
     }
-    case SkillType.HanziWordToPinyin: {
+    case SkillKind.HanziWordToPinyin: {
       skill = skill as HanziWordSkill;
       const hanziWord = hanziWordFromSkill(skill);
       return (
@@ -53,7 +53,7 @@ export const SkillRefText = ({
         />
       );
     }
-    case SkillType.HanziWordToPinyinInitial: {
+    case SkillKind.HanziWordToPinyinInitial: {
       skill = skill as HanziWordSkill;
       const hanziWord = hanziWordFromSkill(skill);
       return (
@@ -68,7 +68,7 @@ export const SkillRefText = ({
         </>
       );
     }
-    case SkillType.HanziWordToPinyinFinal: {
+    case SkillKind.HanziWordToPinyinFinal: {
       skill = skill as HanziWordSkill;
       const hanziWord = hanziWordFromSkill(skill);
       return (
@@ -83,7 +83,7 @@ export const SkillRefText = ({
         </>
       );
     }
-    case SkillType.HanziWordToPinyinTone: {
+    case SkillKind.HanziWordToPinyinTone: {
       skill = skill as HanziWordSkill;
       const hanziWord = hanziWordFromSkill(skill);
       return (
@@ -98,10 +98,10 @@ export const SkillRefText = ({
         </>
       );
     }
-    case SkillType.GlossToHanziWord:
-    case SkillType.PinyinToHanziWord:
-    case SkillType.ImageToHanziWord:
-    case SkillType.HanziWordToGloss: {
+    case SkillKind.GlossToHanziWord:
+    case SkillKind.PinyinToHanziWord:
+    case SkillKind.ImageToHanziWord:
+    case SkillKind.HanziWordToGloss: {
       skill = skill as HanziWordSkill;
       const hanziWord = hanziWordFromSkill(skill);
       return <HanziWordRefText hanziWord={hanziWord} context={context} />;

--- a/projects/app/src/client/ui/WikiHanziWordModal.tsx
+++ b/projects/app/src/client/ui/WikiHanziWordModal.tsx
@@ -3,12 +3,12 @@ import { useHanziWordMeaning } from "@/client/hooks/useHanziWordMeaning";
 import { useLocalQuery } from "@/client/hooks/useLocalQuery";
 import { splitHanziText } from "@/data/hanzi";
 import type { HanziWord } from "@/data/model";
-import { hanziWordSkillTypes } from "@/data/model";
+import { hanziWordSkillKinds } from "@/data/model";
 import type { Skill, SkillRating, SkillState } from "@/data/rizzleSchema";
 import {
   hanziWordSkill,
-  skillTypeFromSkill,
-  skillTypeToShorthand,
+  skillKindFromSkill,
+  skillKindToShorthand,
 } from "@/data/skills";
 import { hanziFromHanziWord, lookupHanzi } from "@/dictionary/dictionary";
 import { Fragment, useMemo } from "react";
@@ -37,7 +37,7 @@ export const WikiHanziWordModal = ({
   );
 
   const skills = useMemo(() => {
-    return hanziWordSkillTypes.map((skillType) =>
+    return hanziWordSkillKinds.map((skillType) =>
       hanziWordSkill(skillType, hanziWord),
     );
   }, [hanziWord]);
@@ -209,7 +209,7 @@ export const WikiHanziWordModal = ({
                     {skillStatesQuery.data.map(([skill, skillState], i) => (
                       <View key={i} className="flex-row items-center gap-2">
                         <Text>
-                          {skillTypeToShorthand(skillTypeFromSkill(skill))}
+                          {skillKindToShorthand(skillKindFromSkill(skill))}
                         </Text>
                         <Text>
                           {Math.min(

--- a/projects/app/src/data/generator.ts
+++ b/projects/app/src/data/generator.ts
@@ -6,41 +6,41 @@ import { hanziWordToPinyinFinalQuestionOrThrow } from "./generators/hanziWordToP
 import { hanziWordToPinyinInitialQuestionOrThrow } from "./generators/hanziWordToPinyinInitial";
 import { hanziWordToPinyinToneQuestionOrThrow } from "./generators/hanziWordToPinyinTone";
 import type { HanziWord, Question } from "./model";
-import { SkillType } from "./model";
+import { SkillKind } from "./model";
 import type { HanziWordSkill, Skill } from "./rizzleSchema";
-import { skillTypeFromSkill } from "./skills";
+import { skillKindFromSkill } from "./skills";
 
 export async function generateQuestionForSkillOrThrow(
   skill: Skill,
 ): Promise<Question> {
-  switch (skillTypeFromSkill(skill)) {
-    case SkillType.HanziWordToGloss: {
+  switch (skillKindFromSkill(skill)) {
+    case SkillKind.HanziWordToGloss: {
       skill = skill as HanziWordSkill;
       return await hanziWordToGlossQuestionOrThrow(skill);
     }
-    case SkillType.HanziWordToPinyinInitial: {
+    case SkillKind.HanziWordToPinyinInitial: {
       skill = skill as HanziWordSkill;
       return await hanziWordToPinyinInitialQuestionOrThrow(skill);
     }
-    case SkillType.HanziWordToPinyinFinal: {
+    case SkillKind.HanziWordToPinyinFinal: {
       skill = skill as HanziWordSkill;
       return await hanziWordToPinyinFinalQuestionOrThrow(skill);
     }
-    case SkillType.HanziWordToPinyinTone: {
+    case SkillKind.HanziWordToPinyinTone: {
       skill = skill as HanziWordSkill;
       return await hanziWordToPinyinToneQuestionOrThrow(skill);
     }
-    case SkillType.Deprecated_EnglishToRadical:
-    case SkillType.Deprecated_PinyinToRadical:
-    case SkillType.Deprecated_RadicalToEnglish:
-    case SkillType.Deprecated_RadicalToPinyin:
-    case SkillType.Deprecated:
-    case SkillType.GlossToHanziWord:
-    case SkillType.HanziWordToPinyin:
-    case SkillType.ImageToHanziWord:
-    case SkillType.PinyinFinalAssociation:
-    case SkillType.PinyinInitialAssociation:
-    case SkillType.PinyinToHanziWord: {
+    case SkillKind.Deprecated_EnglishToRadical:
+    case SkillKind.Deprecated_PinyinToRadical:
+    case SkillKind.Deprecated_RadicalToEnglish:
+    case SkillKind.Deprecated_RadicalToPinyin:
+    case SkillKind.Deprecated:
+    case SkillKind.GlossToHanziWord:
+    case SkillKind.HanziWordToPinyin:
+    case SkillKind.ImageToHanziWord:
+    case SkillKind.PinyinFinalAssociation:
+    case SkillKind.PinyinInitialAssociation:
+    case SkillKind.PinyinToHanziWord: {
       throw new Error(`todo: not implemented`);
     }
   }

--- a/projects/app/src/data/generators/hanziWordToGloss.ts
+++ b/projects/app/src/data/generators/hanziWordToGloss.ts
@@ -18,23 +18,23 @@ import type {
   OneCorrectPairQuestionChoice,
   Question,
 } from "../model";
-import { QuestionType, SkillType } from "../model";
+import { QuestionKind, SkillKind } from "../model";
 import type { HanziWordSkill, Skill } from "../rizzleSchema";
-import { hanziWordFromSkill, skillTypeFromSkill } from "../skills";
+import { hanziWordFromSkill, skillKindFromSkill } from "../skills";
 
 // generate a question to test a skill
 export async function hanziWordToGlossQuestionOrThrow(
   skill: Skill,
 ): Promise<Question> {
-  switch (skillTypeFromSkill(skill)) {
-    case SkillType.HanziWordToGloss: {
+  switch (skillKindFromSkill(skill)) {
+    case SkillKind.HanziWordToGloss: {
       skill = skill as HanziWordSkill;
       const hanziWord = hanziWordFromSkill(skill);
       const meaning = await lookupHanziWord(hanziWord);
       const rowCount = 5;
       const answer: OneCorrectPairQuestionAnswer = {
-        a: { type: `hanzi`, value: hanziFromHanziWord(hanziWord) },
-        b: { type: `gloss`, value: glossOrThrow(hanziWord, meaning) },
+        a: { kind: `hanzi`, value: hanziFromHanziWord(hanziWord) },
+        b: { kind: `gloss`, value: glossOrThrow(hanziWord, meaning) },
         skill,
       };
 
@@ -44,33 +44,33 @@ export async function hanziWordToGlossQuestionOrThrow(
 
       const groupA: OneCorrectPairQuestionChoice[] = groupAHanziWords.map(
         ([hanziWord, _meaning]) => ({
-          type: `hanzi`,
+          kind: `hanzi`,
           value: hanziFromHanziWord(hanziWord),
         }),
       );
       const groupB: OneCorrectPairQuestionChoice[] = groupBHanziWords.map(
         ([hanziWord, meaning]) => ({
-          type: `gloss`,
+          kind: `gloss`,
           value: glossOrThrow(hanziWord, meaning),
         }),
       );
 
       return validQuestionInvariant({
-        type: QuestionType.OneCorrectPair,
+        kind: QuestionKind.OneCorrectPair,
         prompt: `Match a word with its name`,
         groupA: shuffle([...groupA, answer.a]),
         groupB: shuffle([...groupB, answer.b]),
         answer,
       });
     }
-    case SkillType.HanziWordToPinyin: {
+    case SkillKind.HanziWordToPinyin: {
       skill = skill as HanziWordSkill;
       const hanziWord = hanziWordFromSkill(skill);
       const meaning = await lookupHanziWord(hanziWord);
       const rowCount = 5;
       const answer: OneCorrectPairQuestionAnswer = {
-        a: { type: `hanzi`, value: hanziFromHanziWord(hanziWord) },
-        b: { type: `pinyin`, value: pinyinOrThrow(hanziWord, meaning) },
+        a: { kind: `hanzi`, value: hanziFromHanziWord(hanziWord) },
+        b: { kind: `pinyin`, value: pinyinOrThrow(hanziWord, meaning) },
         skill,
       };
 
@@ -80,38 +80,38 @@ export async function hanziWordToGlossQuestionOrThrow(
 
       const groupA: OneCorrectPairQuestionChoice[] = groupAHanziWords.map(
         ([hanziWord, _meaning]) => ({
-          type: `hanzi`,
+          kind: `hanzi`,
           value: hanziFromHanziWord(hanziWord),
         }),
       );
       const groupB: OneCorrectPairQuestionChoice[] = groupBHanziWords.map(
         ([hanziWord, meaning]) => ({
-          type: `gloss`,
+          kind: `gloss`,
           value: glossOrThrow(hanziWord, meaning),
         }),
       );
 
       return validQuestionInvariant({
-        type: QuestionType.OneCorrectPair,
+        kind: QuestionKind.OneCorrectPair,
         prompt: `Match a word with its name`,
         groupA: shuffle([...groupA, answer.a]),
         groupB: shuffle([...groupB, answer.b]),
         answer,
       });
     }
-    case SkillType.Deprecated_EnglishToRadical:
-    case SkillType.Deprecated_PinyinToRadical:
-    case SkillType.Deprecated_RadicalToEnglish:
-    case SkillType.Deprecated_RadicalToPinyin:
-    case SkillType.Deprecated:
-    case SkillType.GlossToHanziWord:
-    case SkillType.HanziWordToPinyinFinal:
-    case SkillType.HanziWordToPinyinInitial:
-    case SkillType.HanziWordToPinyinTone:
-    case SkillType.ImageToHanziWord:
-    case SkillType.PinyinFinalAssociation:
-    case SkillType.PinyinInitialAssociation:
-    case SkillType.PinyinToHanziWord: {
+    case SkillKind.Deprecated_EnglishToRadical:
+    case SkillKind.Deprecated_PinyinToRadical:
+    case SkillKind.Deprecated_RadicalToEnglish:
+    case SkillKind.Deprecated_RadicalToPinyin:
+    case SkillKind.Deprecated:
+    case SkillKind.GlossToHanziWord:
+    case SkillKind.HanziWordToPinyinFinal:
+    case SkillKind.HanziWordToPinyinInitial:
+    case SkillKind.HanziWordToPinyinTone:
+    case SkillKind.ImageToHanziWord:
+    case SkillKind.PinyinFinalAssociation:
+    case SkillKind.PinyinInitialAssociation:
+    case SkillKind.PinyinToHanziWord: {
       throw new Error(`todo: not implemented`);
     }
   }
@@ -237,8 +237,8 @@ async function getWrongHanziWordAnswers(
 }
 
 function validQuestionInvariant(question: Question) {
-  switch (question.type) {
-    case QuestionType.OneCorrectPair: {
+  switch (question.kind) {
+    case QuestionKind.OneCorrectPair: {
       // Ensure there aren't two identical choices in the same group.
       uniqueInvariant(question.groupA.map((x) => x.value));
       uniqueInvariant(question.groupB.map((x) => x.value));
@@ -246,7 +246,8 @@ function validQuestionInvariant(question: Question) {
       invariant(question.groupB.includes(question.answer.b));
       break;
     }
-    case QuestionType.MultipleChoice: {
+    case QuestionKind.HanziToPinyin:
+    case QuestionKind.MultipleChoice: {
       break;
     }
   }

--- a/projects/app/src/data/generators/hanziWordToPinyinFinal.ts
+++ b/projects/app/src/data/generators/hanziWordToPinyinFinal.ts
@@ -24,7 +24,7 @@ import type {
   PinyinText,
   Question,
 } from "../model";
-import { QuestionType } from "../model";
+import { QuestionKind } from "../model";
 import type { HanziWordSkill } from "../rizzleSchema";
 import { hanziOrPinyinWordCount, hanziWordFromSkill } from "../skills";
 
@@ -35,8 +35,8 @@ export async function hanziWordToPinyinFinalQuestionOrThrow(
   const meaning = await lookupHanziWord(hanziWord);
   const rowCount = 5;
   const answer: OneCorrectPairQuestionAnswer = {
-    a: { type: `hanzi`, value: hanziFromHanziWord(hanziWord) },
-    b: { type: `pinyin`, value: pinyinOrThrow(hanziWord, meaning) },
+    a: { kind: `hanzi`, value: hanziFromHanziWord(hanziWord) },
+    b: { kind: `pinyin`, value: pinyinOrThrow(hanziWord, meaning) },
     skill,
   };
 
@@ -44,14 +44,14 @@ export async function hanziWordToPinyinFinalQuestionOrThrow(
   await addDistractors(ctx, rowCount - 1);
 
   const groupA: OneCorrectPairQuestionChoice[] = ctx.hanziDistractors.map(
-    (hanzi) => ({ type: `hanzi`, value: hanzi }),
+    (hanzi) => ({ kind: `hanzi`, value: hanzi }),
   );
   const groupB: OneCorrectPairQuestionChoice[] = ctx.pinyinDistractors.map(
-    (pinyin) => ({ type: `pinyin`, value: pinyin }),
+    (pinyin) => ({ kind: `pinyin`, value: pinyin }),
   );
 
   return validQuestionInvariant({
-    type: QuestionType.OneCorrectPair,
+    kind: QuestionKind.OneCorrectPair,
     prompt: `Match a word with its pinyin`,
     groupA: shuffle([...groupA, answer.a]),
     groupB: shuffle([...groupB, answer.b]),
@@ -203,8 +203,8 @@ async function addDistractors(
 }
 
 function validQuestionInvariant(question: Question) {
-  switch (question.type) {
-    case QuestionType.OneCorrectPair: {
+  switch (question.kind) {
+    case QuestionKind.OneCorrectPair: {
       // Ensure there aren't two identical choices in the same group.
       uniqueInvariant(question.groupA.map((x) => x.value));
       uniqueInvariant(question.groupB.map((x) => x.value));
@@ -226,7 +226,8 @@ function validQuestionInvariant(question: Question) {
       );
       break;
     }
-    case QuestionType.MultipleChoice: {
+    case QuestionKind.HanziToPinyin:
+    case QuestionKind.MultipleChoice: {
       break;
     }
   }

--- a/projects/app/src/data/generators/hanziWordToPinyinInitial.ts
+++ b/projects/app/src/data/generators/hanziWordToPinyinInitial.ts
@@ -23,7 +23,7 @@ import type {
   PinyinText,
   Question,
 } from "../model";
-import { QuestionType } from "../model";
+import { QuestionKind } from "../model";
 import type { HanziWordSkill } from "../rizzleSchema";
 import { hanziOrPinyinWordCount, hanziWordFromSkill } from "../skills";
 
@@ -34,8 +34,8 @@ export async function hanziWordToPinyinInitialQuestionOrThrow(
   const meaning = await lookupHanziWord(hanziWord);
   const rowCount = 5;
   const answer: OneCorrectPairQuestionAnswer = {
-    a: { type: `hanzi`, value: hanziFromHanziWord(hanziWord) },
-    b: { type: `pinyin`, value: pinyinOrThrow(hanziWord, meaning) },
+    a: { kind: `hanzi`, value: hanziFromHanziWord(hanziWord) },
+    b: { kind: `pinyin`, value: pinyinOrThrow(hanziWord, meaning) },
     skill,
   };
 
@@ -43,14 +43,14 @@ export async function hanziWordToPinyinInitialQuestionOrThrow(
   await addDistractors(ctx, rowCount - 1);
 
   const groupA: OneCorrectPairQuestionChoice[] = ctx.hanziDistractors.map(
-    (hanzi) => ({ type: `hanzi`, value: hanzi }),
+    (hanzi) => ({ kind: `hanzi`, value: hanzi }),
   );
   const groupB: OneCorrectPairQuestionChoice[] = ctx.pinyinDistractors.map(
-    (pinyin) => ({ type: `pinyin`, value: pinyin }),
+    (pinyin) => ({ kind: `pinyin`, value: pinyin }),
   );
 
   return validQuestionInvariant({
-    type: QuestionType.OneCorrectPair,
+    kind: QuestionKind.OneCorrectPair,
     prompt: `Match a word with its pinyin`,
     groupA: shuffle([...groupA, answer.a]),
     groupB: shuffle([...groupB, answer.b]),
@@ -198,8 +198,8 @@ async function addDistractors(
 }
 
 function validQuestionInvariant(question: Question) {
-  switch (question.type) {
-    case QuestionType.OneCorrectPair: {
+  switch (question.kind) {
+    case QuestionKind.OneCorrectPair: {
       // Ensure there aren't two identical choices in the same group.
       uniqueInvariant(question.groupA.map((x) => x.value));
       uniqueInvariant(question.groupB.map((x) => x.value));
@@ -221,7 +221,8 @@ function validQuestionInvariant(question: Question) {
       );
       break;
     }
-    case QuestionType.MultipleChoice: {
+    case QuestionKind.HanziToPinyin:
+    case QuestionKind.MultipleChoice: {
       break;
     }
   }

--- a/projects/app/src/data/generators/hanziWordToPinyinTone.ts
+++ b/projects/app/src/data/generators/hanziWordToPinyinTone.ts
@@ -25,7 +25,7 @@ import type {
   PinyinText,
   Question,
 } from "../model";
-import { QuestionType } from "../model";
+import { QuestionKind } from "../model";
 import type { HanziWordSkill } from "../rizzleSchema";
 import { hanziOrPinyinWordCount, hanziWordFromSkill } from "../skills";
 
@@ -36,8 +36,8 @@ export async function hanziWordToPinyinToneQuestionOrThrow(
   const meaning = await lookupHanziWord(hanziWord);
   const rowCount = 5;
   const answer: OneCorrectPairQuestionAnswer = {
-    a: { type: `hanzi`, value: hanziFromHanziWord(hanziWord) },
-    b: { type: `pinyin`, value: pinyinOrThrow(hanziWord, meaning) },
+    a: { kind: `hanzi`, value: hanziFromHanziWord(hanziWord) },
+    b: { kind: `pinyin`, value: pinyinOrThrow(hanziWord, meaning) },
     skill,
   };
 
@@ -45,14 +45,14 @@ export async function hanziWordToPinyinToneQuestionOrThrow(
   await addDistractors(ctx, rowCount - 1);
 
   const groupA: OneCorrectPairQuestionChoice[] = ctx.hanziDistractors.map(
-    (hanzi) => ({ type: `hanzi`, value: hanzi }),
+    (hanzi) => ({ kind: `hanzi`, value: hanzi }),
   );
   const groupB: OneCorrectPairQuestionChoice[] = ctx.pinyinDistractors.map(
-    (pinyin) => ({ type: `pinyin`, value: pinyin }),
+    (pinyin) => ({ kind: `pinyin`, value: pinyin }),
   );
 
   return validQuestionInvariant({
-    type: QuestionType.OneCorrectPair,
+    kind: QuestionKind.OneCorrectPair,
     prompt: `Match a word with its pinyin`,
     groupA: shuffle([...groupA, answer.a]),
     groupB: shuffle([...groupB, answer.b]),
@@ -220,8 +220,8 @@ async function addDistractors(
 }
 
 function validQuestionInvariant(question: Question) {
-  switch (question.type) {
-    case QuestionType.OneCorrectPair: {
+  switch (question.kind) {
+    case QuestionKind.OneCorrectPair: {
       // Ensure there aren't two identical choices in the same group.
       uniqueInvariant(question.groupA.map((x) => x.value));
       uniqueInvariant(question.groupB.map((x) => x.value));
@@ -235,7 +235,8 @@ function validQuestionInvariant(question: Question) {
       ]);
       break;
     }
-    case QuestionType.MultipleChoice: {
+    case QuestionKind.HanziToPinyin:
+    case QuestionKind.MultipleChoice: {
       break;
     }
   }

--- a/projects/app/src/data/hanzi.ts
+++ b/projects/app/src/data/hanzi.ts
@@ -6,91 +6,91 @@ import { z } from "zod/v4";
 
 export type IdsNode =
   | {
-      type: typeof IdsOperator.LeftToRight;
+      operator: typeof IdsOperator.LeftToRight;
       left: IdsNode;
       right: IdsNode;
     }
   | {
-      type: typeof IdsOperator.AboveToBelow;
+      operator: typeof IdsOperator.AboveToBelow;
       above: IdsNode;
       below: IdsNode;
     }
   | {
-      type: typeof IdsOperator.LeftToMiddleToRight;
+      operator: typeof IdsOperator.LeftToMiddleToRight;
       left: IdsNode;
       middle: IdsNode;
       right: IdsNode;
     }
   | {
-      type: typeof IdsOperator.AboveToMiddleAndBelow;
+      operator: typeof IdsOperator.AboveToMiddleAndBelow;
       above: IdsNode;
       middle: IdsNode;
       below: IdsNode;
     }
   | {
-      type: typeof IdsOperator.FullSurround;
+      operator: typeof IdsOperator.FullSurround;
       surrounding: IdsNode;
       surrounded: IdsNode;
     }
   | {
-      type: typeof IdsOperator.SurroundFromAbove;
+      operator: typeof IdsOperator.SurroundFromAbove;
       above: IdsNode;
       surrounded: IdsNode;
     }
   | {
-      type: typeof IdsOperator.SurroundFromBelow;
+      operator: typeof IdsOperator.SurroundFromBelow;
       below: IdsNode;
       surrounded: IdsNode;
     }
   | {
-      type: typeof IdsOperator.SurroundFromLeft;
+      operator: typeof IdsOperator.SurroundFromLeft;
       left: IdsNode;
       surrounded: IdsNode;
     }
   | {
-      type: typeof IdsOperator.SurroundFromRight;
+      operator: typeof IdsOperator.SurroundFromRight;
       right: IdsNode;
       surrounded: IdsNode;
     }
   | {
-      type: typeof IdsOperator.SurroundFromUpperLeft;
+      operator: typeof IdsOperator.SurroundFromUpperLeft;
       upperLeft: IdsNode;
       surrounded: IdsNode;
     }
   | {
-      type: typeof IdsOperator.SurroundFromUpperRight;
+      operator: typeof IdsOperator.SurroundFromUpperRight;
       upperRight: IdsNode;
       surrounded: IdsNode;
     }
   | {
-      type: typeof IdsOperator.SurroundFromLowerLeft;
+      operator: typeof IdsOperator.SurroundFromLowerLeft;
       lowerLeft: IdsNode;
       surrounded: IdsNode;
     }
   | {
-      type: typeof IdsOperator.SurroundFromLowerRight;
+      operator: typeof IdsOperator.SurroundFromLowerRight;
       lowerRight: IdsNode;
       surrounded: IdsNode;
     }
   | {
-      type: typeof IdsOperator.Overlaid;
+      operator: typeof IdsOperator.Overlaid;
       overlay: IdsNode;
       underlay: IdsNode;
     }
   | {
-      type: typeof IdsOperator.HorizontalReflection;
+      operator: typeof IdsOperator.HorizontalReflection;
       reflected: IdsNode;
     }
   | {
-      type: typeof IdsOperator.Rotation;
+      operator: typeof IdsOperator.Rotation;
       rotated: IdsNode;
     }
   | {
-      type: `LeafCharacter`;
+      operator: `LeafCharacter`;
       character: HanziChar;
     }
   | {
-      type: `LeafUnknownCharacter`;
+      operator: `LeafUnknownCharacter`;
       strokeCount: number;
     };
 
@@ -131,25 +131,30 @@ export function parseIds(ids: string, cursor?: { index: number }): IdsNode {
       case IdsOperator.LeftToRight: {
         const left = parseIds(ids, cursor);
         const right = parseIds(ids, cursor);
-        return { type: IdsOperator.LeftToRight, left, right };
+        return { operator: IdsOperator.LeftToRight, left, right };
       }
       case IdsOperator.AboveToBelow: {
         const above = parseIds(ids, cursor);
         const below = parseIds(ids, cursor);
-        return { type: IdsOperator.AboveToBelow, above, below };
+        return { operator: IdsOperator.AboveToBelow, above, below };
       }
       case IdsOperator.LeftToMiddleToRight: {
         const left = parseIds(ids, cursor);
         const middle = parseIds(ids, cursor);
         const right = parseIds(ids, cursor);
-        return { type: IdsOperator.LeftToMiddleToRight, left, middle, right };
+        return {
+          operator: IdsOperator.LeftToMiddleToRight,
+          left,
+          middle,
+          right,
+        };
       }
       case IdsOperator.AboveToMiddleAndBelow: {
         const above = parseIds(ids, cursor);
         const middle = parseIds(ids, cursor);
         const below = parseIds(ids, cursor);
         return {
-          type: IdsOperator.AboveToMiddleAndBelow,
+          operator: IdsOperator.AboveToMiddleAndBelow,
           above,
           middle,
           below,
@@ -158,33 +163,49 @@ export function parseIds(ids: string, cursor?: { index: number }): IdsNode {
       case IdsOperator.FullSurround: {
         const surrounding = parseIds(ids, cursor);
         const surrounded = parseIds(ids, cursor);
-        return { type: IdsOperator.FullSurround, surrounding, surrounded };
+        return {
+          operator: IdsOperator.FullSurround,
+          surrounding,
+          surrounded,
+        };
       }
       case IdsOperator.SurroundFromAbove: {
         const above = parseIds(ids, cursor);
         const surrounded = parseIds(ids, cursor);
-        return { type: IdsOperator.SurroundFromAbove, above, surrounded };
+        return {
+          operator: IdsOperator.SurroundFromAbove,
+          above,
+          surrounded,
+        };
       }
       case IdsOperator.SurroundFromBelow: {
         const below = parseIds(ids, cursor);
         const surrounded = parseIds(ids, cursor);
-        return { type: IdsOperator.SurroundFromBelow, below, surrounded };
+        return {
+          operator: IdsOperator.SurroundFromBelow,
+          below,
+          surrounded,
+        };
       }
       case IdsOperator.SurroundFromLeft: {
         const left = parseIds(ids, cursor);
         const surrounded = parseIds(ids, cursor);
-        return { type: IdsOperator.SurroundFromLeft, left, surrounded };
+        return { operator: IdsOperator.SurroundFromLeft, left, surrounded };
       }
       case IdsOperator.SurroundFromRight: {
         const right = parseIds(ids, cursor);
         const surrounded = parseIds(ids, cursor);
-        return { type: IdsOperator.SurroundFromRight, right, surrounded };
+        return {
+          operator: IdsOperator.SurroundFromRight,
+          right,
+          surrounded,
+        };
       }
       case IdsOperator.SurroundFromUpperLeft: {
         const upperLeft = parseIds(ids, cursor);
         const surrounded = parseIds(ids, cursor);
         return {
-          type: IdsOperator.SurroundFromUpperLeft,
+          operator: IdsOperator.SurroundFromUpperLeft,
           upperLeft,
           surrounded,
         };
@@ -193,7 +214,7 @@ export function parseIds(ids: string, cursor?: { index: number }): IdsNode {
         const upperRight = parseIds(ids, cursor);
         const surrounded = parseIds(ids, cursor);
         return {
-          type: IdsOperator.SurroundFromUpperRight,
+          operator: IdsOperator.SurroundFromUpperRight,
           upperRight,
           surrounded,
         };
@@ -202,7 +223,7 @@ export function parseIds(ids: string, cursor?: { index: number }): IdsNode {
         const lowerLeft = parseIds(ids, cursor);
         const surrounded = parseIds(ids, cursor);
         return {
-          type: IdsOperator.SurroundFromLowerLeft,
+          operator: IdsOperator.SurroundFromLowerLeft,
           lowerLeft,
           surrounded,
         };
@@ -211,7 +232,7 @@ export function parseIds(ids: string, cursor?: { index: number }): IdsNode {
         const lowerRight = parseIds(ids, cursor);
         const surrounded = parseIds(ids, cursor);
         return {
-          type: IdsOperator.SurroundFromLowerRight,
+          operator: IdsOperator.SurroundFromLowerRight,
           lowerRight,
           surrounded,
         };
@@ -219,15 +240,15 @@ export function parseIds(ids: string, cursor?: { index: number }): IdsNode {
       case IdsOperator.Overlaid: {
         const overlay = parseIds(ids, cursor);
         const underlay = parseIds(ids, cursor);
-        return { type: IdsOperator.Overlaid, overlay, underlay };
+        return { operator: IdsOperator.Overlaid, overlay, underlay };
       }
       case IdsOperator.HorizontalReflection: {
         const reflected = parseIds(ids, cursor);
-        return { type: IdsOperator.HorizontalReflection, reflected };
+        return { operator: IdsOperator.HorizontalReflection, reflected };
       }
       case IdsOperator.Rotation: {
         const rotated = parseIds(ids, cursor);
-        return { type: IdsOperator.Rotation, rotated };
+        return { operator: IdsOperator.Rotation, rotated };
       }
       default: {
         throw new Error(`unexpected combining character ${char}`);
@@ -237,10 +258,10 @@ export function parseIds(ids: string, cursor?: { index: number }): IdsNode {
 
   const strokeCount = strokeCountPlaceholderOrNull(charCodePoint);
   if (strokeCount != null) {
-    return { type: `LeafUnknownCharacter`, strokeCount };
+    return { operator: `LeafUnknownCharacter`, strokeCount };
   }
 
-  return { type: `LeafCharacter`, character: char as HanziChar };
+  return { operator: `LeafCharacter`, character: char as HanziChar };
 }
 
 export function strokeCountPlaceholderOrNull(
@@ -257,68 +278,68 @@ export function strokeCountPlaceholderOrNull(
 }
 
 export function idsNodeToString(ids: IdsNode): string {
-  switch (ids.type) {
+  switch (ids.operator) {
     case IdsOperator.LeftToRight: {
-      return `${ids.type}${idsNodeToString(ids.left)}${idsNodeToString(ids.right)}`;
+      return `${ids.operator}${idsNodeToString(ids.left)}${idsNodeToString(ids.right)}`;
     }
     case IdsOperator.AboveToBelow: {
-      return `${ids.type}${idsNodeToString(ids.above)}${idsNodeToString(ids.below)}`;
+      return `${ids.operator}${idsNodeToString(ids.above)}${idsNodeToString(ids.below)}`;
     }
     case IdsOperator.LeftToMiddleToRight: {
-      return `${ids.type}${idsNodeToString(ids.left)}${idsNodeToString(
+      return `${ids.operator}${idsNodeToString(ids.left)}${idsNodeToString(
         ids.middle,
       )}${idsNodeToString(ids.right)}`;
     }
     case IdsOperator.AboveToMiddleAndBelow: {
-      return `${ids.type}${idsNodeToString(ids.above)}${idsNodeToString(
+      return `${ids.operator}${idsNodeToString(ids.above)}${idsNodeToString(
         ids.middle,
       )}${idsNodeToString(ids.below)}`;
     }
     case IdsOperator.FullSurround: {
-      return `${ids.type}${idsNodeToString(ids.surrounding)}${idsNodeToString(
+      return `${ids.operator}${idsNodeToString(ids.surrounding)}${idsNodeToString(
         ids.surrounded,
       )}`;
     }
     case IdsOperator.SurroundFromAbove: {
-      return `${ids.type}${idsNodeToString(ids.above)}${idsNodeToString(ids.surrounded)}`;
+      return `${ids.operator}${idsNodeToString(ids.above)}${idsNodeToString(ids.surrounded)}`;
     }
     case IdsOperator.SurroundFromBelow: {
-      return `${ids.type}${idsNodeToString(ids.below)}${idsNodeToString(ids.surrounded)}`;
+      return `${ids.operator}${idsNodeToString(ids.below)}${idsNodeToString(ids.surrounded)}`;
     }
     case IdsOperator.SurroundFromLeft: {
-      return `${ids.type}${idsNodeToString(ids.left)}${idsNodeToString(ids.surrounded)}`;
+      return `${ids.operator}${idsNodeToString(ids.left)}${idsNodeToString(ids.surrounded)}`;
     }
     case IdsOperator.SurroundFromRight: {
-      return `${ids.type}${idsNodeToString(ids.right)}${idsNodeToString(ids.surrounded)}`;
+      return `${ids.operator}${idsNodeToString(ids.right)}${idsNodeToString(ids.surrounded)}`;
     }
     case IdsOperator.SurroundFromUpperLeft: {
-      return `${ids.type}${idsNodeToString(ids.upperLeft)}${idsNodeToString(
+      return `${ids.operator}${idsNodeToString(ids.upperLeft)}${idsNodeToString(
         ids.surrounded,
       )}`;
     }
     case IdsOperator.SurroundFromUpperRight: {
-      return `${ids.type}${idsNodeToString(ids.upperRight)}${idsNodeToString(
+      return `${ids.operator}${idsNodeToString(ids.upperRight)}${idsNodeToString(
         ids.surrounded,
       )}`;
     }
     case IdsOperator.SurroundFromLowerLeft: {
-      return `${ids.type}${idsNodeToString(ids.lowerLeft)}${idsNodeToString(
+      return `${ids.operator}${idsNodeToString(ids.lowerLeft)}${idsNodeToString(
         ids.surrounded,
       )}`;
     }
     case IdsOperator.SurroundFromLowerRight: {
-      return `${ids.type}${idsNodeToString(ids.lowerRight)}${idsNodeToString(
+      return `${ids.operator}${idsNodeToString(ids.lowerRight)}${idsNodeToString(
         ids.surrounded,
       )}`;
     }
     case IdsOperator.Overlaid: {
-      return `${ids.type}${idsNodeToString(ids.overlay)}${idsNodeToString(ids.underlay)}`;
+      return `${ids.operator}${idsNodeToString(ids.overlay)}${idsNodeToString(ids.underlay)}`;
     }
     case IdsOperator.HorizontalReflection: {
-      return `${ids.type}${idsNodeToString(ids.reflected)}`;
+      return `${ids.operator}${idsNodeToString(ids.reflected)}`;
     }
     case IdsOperator.Rotation: {
-      return `${ids.type}${idsNodeToString(ids.rotated)}`;
+      return `${ids.operator}${idsNodeToString(ids.rotated)}`;
     }
     case `LeafCharacter`: {
       return ids.character;
@@ -335,33 +356,33 @@ export function idsNodeToString(ids: IdsNode): string {
  * For example `⿰x⿰yz` can be flattened to `⿲xyz`.
  */
 export function flattenIds(ids: IdsNode): IdsNode {
-  if (ids.type === IdsOperator.AboveToBelow) {
-    if (ids.above.type === IdsOperator.AboveToBelow) {
+  if (ids.operator === IdsOperator.AboveToBelow) {
+    if (ids.above.operator === IdsOperator.AboveToBelow) {
       return {
-        type: IdsOperator.AboveToMiddleAndBelow,
+        operator: IdsOperator.AboveToMiddleAndBelow,
         above: flattenIds(ids.above.above),
         middle: flattenIds(ids.above.below),
         below: flattenIds(ids.below),
       };
-    } else if (ids.below.type === IdsOperator.AboveToBelow) {
+    } else if (ids.below.operator === IdsOperator.AboveToBelow) {
       return {
-        type: IdsOperator.AboveToMiddleAndBelow,
+        operator: IdsOperator.AboveToMiddleAndBelow,
         above: flattenIds(ids.above),
         middle: flattenIds(ids.below.above),
         below: flattenIds(ids.below.below),
       };
     }
-  } else if (ids.type === IdsOperator.LeftToRight) {
-    if (ids.left.type === IdsOperator.LeftToRight) {
+  } else if (ids.operator === IdsOperator.LeftToRight) {
+    if (ids.left.operator === IdsOperator.LeftToRight) {
       return {
-        type: IdsOperator.LeftToMiddleToRight,
+        operator: IdsOperator.LeftToMiddleToRight,
         left: flattenIds(ids.left.left),
         middle: flattenIds(ids.left.right),
         right: flattenIds(ids.right),
       };
-    } else if (ids.right.type === IdsOperator.LeftToRight) {
+    } else if (ids.right.operator === IdsOperator.LeftToRight) {
       return {
-        type: IdsOperator.LeftToMiddleToRight,
+        operator: IdsOperator.LeftToMiddleToRight,
         left: flattenIds(ids.left),
         middle: flattenIds(ids.right.left),
         right: flattenIds(ids.right.right),
@@ -376,10 +397,10 @@ export function* walkIdsNode(
 ): Generator<
   StrictExtract<
     IdsNode,
-    { type: `LeafCharacter` } | { type: `LeafUnknownCharacter` }
+    { operator: `LeafCharacter` } | { operator: `LeafUnknownCharacter` }
   >
 > {
-  switch (ids.type) {
+  switch (ids.operator) {
     case IdsOperator.LeftToRight: {
       yield* walkIdsNode(ids.left);
       yield* walkIdsNode(ids.right);

--- a/projects/app/src/data/model.ts
+++ b/projects/app/src/data/model.ts
@@ -266,7 +266,6 @@ export interface OneCorrectPairQuestion {
   answer: OneCorrectPairQuestionAnswer;
   groupA: readonly OneCorrectPairQuestionChoice[];
   groupB: readonly OneCorrectPairQuestionChoice[];
-  hint?: string;
   flag?: QuestionFlag;
 }
 

--- a/projects/app/src/data/model.ts
+++ b/projects/app/src/data/model.ts
@@ -30,33 +30,33 @@ export interface BaseSrsState {
   nextReviewAt: Date;
 }
 
-export const srsTypeSchema = z.enum({
+export const srsKindSchema = z.enum({
   Mock: `debug--Mock`,
   FsrsFourPointFive: `debug--FsrsFourPointFive`,
 });
-export const SrsType = srsTypeSchema.enum;
-export type SrsType = z.infer<typeof srsTypeSchema>;
+export const SrsKind = srsKindSchema.enum;
+export type SrsKind = z.infer<typeof srsKindSchema>;
 
 /**
  * A placeholder to force the code to be structured to allow multiple SRS
  * algorithms. This is not used for anything.
  */
-export interface SrsStateMock extends BaseSrsState {
-  type: typeof SrsType.Mock;
+export interface SrsStateMockType extends BaseSrsState {
+  kind: typeof SrsKind.Mock;
 }
 
 /**
  * FSRS 4.5 specific parameters.
  */
-export interface SrsStateFsrsFourPointFive extends BaseSrsState {
-  type: typeof SrsType.FsrsFourPointFive;
+export interface SrsStateFsrsFourPointFiveType extends BaseSrsState {
+  kind: typeof SrsKind.FsrsFourPointFive;
   stability: number;
   difficulty: number;
 }
 
-export type SrsState = SrsStateMock | SrsStateFsrsFourPointFive;
+export type SrsStateType = SrsStateMockType | SrsStateFsrsFourPointFiveType;
 
-const skillTypeSchema = z.enum({
+const skillKindSchema = z.enum({
   /**
    * When shown a hanzi word, write the english translation.
    */
@@ -94,8 +94,8 @@ const skillTypeSchema = z.enum({
   Deprecated_RadicalToPinyin: `debug--RadicalToPinyin`,
   Deprecated_PinyinToRadical: `debug--PinyinToRadical`,
 });
-export const SkillType = skillTypeSchema.enum;
-export type SkillType = z.infer<typeof skillTypeSchema>;
+export const SkillKind = skillKindSchema.enum;
+export type SkillKind = z.infer<typeof skillKindSchema>;
 
 const partOfSpeechSchema = z.enum({
   Noun: `debug--Noun`,
@@ -112,6 +112,12 @@ const partOfSpeechSchema = z.enum({
 export const PartOfSpeech = partOfSpeechSchema.enum;
 export type PartOfSpeech = z.infer<typeof partOfSpeechSchema>;
 
+/**
+ * A hanzi and meaning pair, e.g. `好:good`.
+ *
+ * Hanzi can have multiple meanings, so this offers a way to represent a word
+ * with a specific meaning.
+ */
 export type HanziWord = (string & z.BRAND<`HanziWord`>) | `${string}:${string}`; // useful when writing literal strings in tests
 
 /**
@@ -132,101 +138,102 @@ export type HanziText = string & z.BRAND<`HanziText`>;
  */
 export type HanziChar = string & z.BRAND<`HanziChar`>;
 
-export type HanziWordSkillType =
-  | typeof SkillType.HanziWordToGloss
-  | typeof SkillType.HanziWordToPinyin
-  | typeof SkillType.HanziWordToPinyinInitial
-  | typeof SkillType.HanziWordToPinyinFinal
-  | typeof SkillType.HanziWordToPinyinTone
-  | typeof SkillType.GlossToHanziWord
-  | typeof SkillType.PinyinToHanziWord
-  | typeof SkillType.ImageToHanziWord;
+export type HanziWordSkillKind =
+  | typeof SkillKind.HanziWordToGloss
+  | typeof SkillKind.HanziWordToPinyin
+  | typeof SkillKind.HanziWordToPinyinInitial
+  | typeof SkillKind.HanziWordToPinyinFinal
+  | typeof SkillKind.HanziWordToPinyinTone
+  | typeof SkillKind.GlossToHanziWord
+  | typeof SkillKind.PinyinToHanziWord
+  | typeof SkillKind.ImageToHanziWord;
 
-export const hanziWordSkillTypes: HanziWordSkillType[] = [
-  SkillType.HanziWordToGloss,
-  SkillType.HanziWordToPinyin,
-  SkillType.HanziWordToPinyinInitial,
-  SkillType.HanziWordToPinyinFinal,
-  SkillType.HanziWordToPinyinTone,
+export const hanziWordSkillKinds: HanziWordSkillKind[] = [
+  SkillKind.HanziWordToGloss,
+  SkillKind.HanziWordToPinyin,
+  SkillKind.HanziWordToPinyinInitial,
+  SkillKind.HanziWordToPinyinFinal,
+  SkillKind.HanziWordToPinyinTone,
 ];
 
-const questionFlagTypeSchema = z.enum({
+const questionFlagKindSchema = z.enum({
   NewSkill: `debug--NewSkill`,
   Overdue: `debug--Overdue`,
   Retry: `debug--Retry`,
   WeakWord: `debug--WeakWord`,
 });
-export const QuestionFlagType = questionFlagTypeSchema.enum;
-export type QuestionFlagType = z.infer<typeof questionFlagTypeSchema>;
+export const QuestionFlagKind = questionFlagKindSchema.enum;
+export type QuestionFlagKind = z.infer<typeof questionFlagKindSchema>;
 
-export interface QuestionFlagRetry {
-  type: typeof QuestionFlagType.Retry;
+export interface QuestionFlagRetryType {
+  kind: typeof QuestionFlagKind.Retry;
 }
 
-export interface QuestionFlagOverdue {
-  type: typeof QuestionFlagType.Overdue;
+export interface QuestionFlagOverdueType {
+  kind: typeof QuestionFlagKind.Overdue;
   interval: Interval;
 }
 
-export interface QuestionFlagWeakWord {
-  type: typeof QuestionFlagType.WeakWord;
+export interface QuestionFlagWeakWordType {
+  kind: typeof QuestionFlagKind.WeakWord;
 }
 
-export interface QuestionFlagNewSkill {
-  type: typeof QuestionFlagType.NewSkill;
+export interface QuestionFlagNewSkillType {
+  kind: typeof QuestionFlagKind.NewSkill;
 }
 
-export type QuestionFlag =
-  | QuestionFlagWeakWord
-  | QuestionFlagNewSkill
-  | QuestionFlagOverdue
-  | QuestionFlagRetry;
+export type QuestionFlagType =
+  | QuestionFlagWeakWordType
+  | QuestionFlagNewSkillType
+  | QuestionFlagOverdueType
+  | QuestionFlagRetryType;
 
-const questionTypeSchema = z.enum({
+const questionKindSchema = z.enum({
   MultipleChoice: `debug--MultipleChoice`,
   OneCorrectPair: `debug--OneCorrectPair`,
+  HanziToPinyin: `debug--HanziToPinyin`,
 });
-export const QuestionType = questionTypeSchema.enum;
-export type QuestionType = z.infer<typeof questionTypeSchema>;
+export const QuestionKind = questionKindSchema.enum;
+export type QuestionKind = z.infer<typeof questionKindSchema>;
 
 export interface MultipleChoiceQuestion {
-  type: typeof QuestionType.MultipleChoice;
+  kind: typeof QuestionKind.MultipleChoice;
   prompt: string;
   answer: string;
-  flag?: QuestionFlag;
+  flag?: QuestionFlagType;
   choices: readonly string[];
 }
 
-const mistakeTypeSchema = z.enum({
+const mistakeKindSchema = z.enum({
   HanziGloss: `debug--HanziGloss`,
   HanziPinyin: `debug--HanziPinyin`,
   HanziPinyinInitial: `debug--HanziPinyinInitial`,
 });
-export const MistakeType = mistakeTypeSchema.enum;
-export type MistakeType = z.infer<typeof mistakeTypeSchema>;
+export const MistakeKind = mistakeKindSchema.enum;
+export type MistakeKind = z.infer<typeof mistakeKindSchema>;
 
-export interface HanziGlossMistake {
-  type: typeof MistakeType.HanziGloss;
+export interface HanziGlossMistakeType {
+  kind: typeof MistakeKind.HanziGloss;
   hanzi: HanziText;
   gloss: string;
 }
 
-export interface HanziPinyinMistake {
-  type: typeof MistakeType.HanziPinyin;
+export interface HanziPinyinMistakeType {
+  kind: typeof MistakeKind.HanziPinyin;
   hanzi: HanziText;
   pinyin: PinyinText;
 }
 
-export interface HanziPinyinInitialMistake {
-  type: typeof MistakeType.HanziPinyinInitial;
+export interface HanziPinyinInitialMistakeType {
+  kind: typeof MistakeKind.HanziPinyinInitial;
   hanzi: string;
   pinyinInitial: string;
 }
 
-export type Mistake =
-  | HanziGlossMistake
-  | HanziPinyinMistake
-  | HanziPinyinInitialMistake;
+export type MistakeType =
+  | HanziGlossMistakeType
+  | HanziPinyinMistakeType
+  | HanziPinyinInitialMistakeType;
 
 export interface NewSkillRating {
   skill: Skill;
@@ -235,17 +242,17 @@ export interface NewSkillRating {
 }
 
 export type OneCorrectPairQuestionHanziChoice = {
-  type: `hanzi`;
+  kind: `hanzi`;
   value: HanziText;
 };
 
 export type OneCorrectPairQuestionGlossChoice = {
-  type: `gloss`;
+  kind: `gloss`;
   value: string;
 };
 
 export type OneCorrectPairQuestionPinyinChoice = {
-  type: `pinyin`;
+  kind: `pinyin`;
   value: PinyinText;
 };
 
@@ -261,15 +268,26 @@ export interface OneCorrectPairQuestionAnswer {
 }
 
 export interface OneCorrectPairQuestion {
-  type: typeof QuestionType.OneCorrectPair;
+  kind: typeof QuestionKind.OneCorrectPair;
   prompt: string;
   answer: OneCorrectPairQuestionAnswer;
   groupA: readonly OneCorrectPairQuestionChoice[];
   groupB: readonly OneCorrectPairQuestionChoice[];
-  flag?: QuestionFlag;
+  flag?: QuestionFlagType;
 }
 
-export type Question = MultipleChoiceQuestion | OneCorrectPairQuestion;
+export interface HanziToPinyinQuestion {
+  kind: typeof QuestionKind.HanziToPinyin;
+  prompt: string;
+  answer: readonly (readonly [HanziChar, /* pinyin */ string])[];
+  skill: Skill;
+  flag?: QuestionFlagType;
+}
+
+export type Question =
+  | MultipleChoiceQuestion
+  | OneCorrectPairQuestion
+  | HanziToPinyinQuestion;
 
 export interface PinyinInitialAssociation {
   initial: string;

--- a/projects/app/src/data/rizzleMutators.ts
+++ b/projects/app/src/data/rizzleMutators.ts
@@ -4,7 +4,7 @@ import type { FsrsState } from "@/util/fsrs";
 import { nextReview } from "@/util/fsrs";
 import type { RizzleReplicacheMutators } from "@/util/rizzle";
 import { invariant } from "@haohaohow/lib/invariant";
-import { MistakeType } from "./model";
+import { MistakeKind } from "./model";
 import type { v7 } from "./rizzleSchema";
 import { srsStateFromFsrsState } from "./rizzleSchema";
 import {
@@ -60,7 +60,7 @@ export const v7Mutators: RizzleReplicacheMutators<typeof v7> = {
     //
     // SAME AS saveHanziPinyinMistake
     if (loadDictionary.isCached()) {
-      const mistake = { type: MistakeType.HanziGloss, gloss, hanzi } as const;
+      const mistake = { kind: MistakeKind.HanziGloss, gloss, hanzi } as const;
 
       // Queue all skills relevant to the gloss.
       for (const skill of await skillsToReReviewForHanziGlossMistake(mistake)) {
@@ -90,7 +90,7 @@ export const v7Mutators: RizzleReplicacheMutators<typeof v7> = {
     //
     // SAME AS saveHanziGlossMistake
     if (loadDictionary.isCached()) {
-      const mistake = { type: MistakeType.HanziPinyin, pinyin, hanzi } as const;
+      const mistake = { kind: MistakeKind.HanziPinyin, pinyin, hanzi } as const;
 
       // Queue all skills relevant to the gloss.
       for (const skill of await skillsToReReviewForHanziPinyinMistake(

--- a/projects/app/src/data/rizzleSchema.ts
+++ b/projects/app/src/data/rizzleSchema.ts
@@ -4,32 +4,32 @@ import { Rating } from "@/util/fsrs";
 import type { RizzleReplicache } from "@/util/rizzle";
 import { r, RizzleCustom } from "@/util/rizzle";
 import { z } from "zod/v4";
-import type { HanziText, PinyinText, SrsState } from "./model";
+import type { HanziText, PinyinText, SrsStateType } from "./model";
 import {
   MnemonicThemeId,
   PartOfSpeech,
   PinyinInitialGroupId,
-  SkillType,
-  SrsType,
+  SkillKind,
+  SrsKind,
 } from "./model";
 
-export const rSkillType = memoize0(function rSkillType() {
-  return r.enum(SkillType, {
-    [SkillType.Deprecated_RadicalToEnglish]: `re`,
-    [SkillType.Deprecated_EnglishToRadical]: `er`,
-    [SkillType.Deprecated_RadicalToPinyin]: `rp`,
-    [SkillType.Deprecated_PinyinToRadical]: `pr`,
-    [SkillType.Deprecated]: `xx`,
-    [SkillType.HanziWordToGloss]: `he`,
-    [SkillType.HanziWordToPinyin]: `hp`,
-    [SkillType.HanziWordToPinyinInitial]: `hpi`,
-    [SkillType.HanziWordToPinyinFinal]: `hpf`,
-    [SkillType.HanziWordToPinyinTone]: `hpt`,
-    [SkillType.GlossToHanziWord]: `eh`,
-    [SkillType.PinyinToHanziWord]: `ph`,
-    [SkillType.ImageToHanziWord]: `ih`,
-    [SkillType.PinyinInitialAssociation]: `pia`,
-    [SkillType.PinyinFinalAssociation]: `pfa`,
+export const rSkillKind = memoize0(function rSkillKind() {
+  return r.enum(SkillKind, {
+    [SkillKind.Deprecated_RadicalToEnglish]: `re`,
+    [SkillKind.Deprecated_EnglishToRadical]: `er`,
+    [SkillKind.Deprecated_RadicalToPinyin]: `rp`,
+    [SkillKind.Deprecated_PinyinToRadical]: `pr`,
+    [SkillKind.Deprecated]: `xx`,
+    [SkillKind.HanziWordToGloss]: `he`,
+    [SkillKind.HanziWordToPinyin]: `hp`,
+    [SkillKind.HanziWordToPinyinInitial]: `hpi`,
+    [SkillKind.HanziWordToPinyinFinal]: `hpf`,
+    [SkillKind.HanziWordToPinyinTone]: `hpt`,
+    [SkillKind.GlossToHanziWord]: `eh`,
+    [SkillKind.PinyinToHanziWord]: `ph`,
+    [SkillKind.ImageToHanziWord]: `ih`,
+    [SkillKind.PinyinInitialAssociation]: `pia`,
+    [SkillKind.PinyinFinalAssociation]: `pfa`,
   });
 });
 
@@ -123,10 +123,10 @@ export const rPinyinText = memoize0(function rPinyinText() {
   );
 });
 
-export const rSrsType = memoize0(function rSrsType() {
-  return r.enum(SrsType, {
-    [SrsType.Mock]: `0`,
-    [SrsType.FsrsFourPointFive]: `1`,
+export const rSrsKind = memoize0(function rSrsKind() {
+  return r.enum(SrsKind, {
+    [SrsKind.Mock]: `0`,
+    [SrsKind.FsrsFourPointFive]: `1`,
   });
 });
 
@@ -137,7 +137,7 @@ export const rSrsState = memoize0(function rSrsParams() {
     //     type: r.literal(SrsType.Null),
     //   }),
     r.object({
-      type: r.literal(SrsType.FsrsFourPointFive, rSrsType()).alias(`t`),
+      kind: r.literal(SrsKind.FsrsFourPointFive, rSrsKind()).alias(`t`),
       stability: r.number().alias(`s` /* (F)SRS (S)tability */),
       difficulty: r.number().alias(`d` /* (F)SRS (D)ifficulty */),
       prevReviewAt: r.datetime().alias(`p`),
@@ -276,12 +276,12 @@ export const v7 = {
 
 export function srsStateFromFsrsState(fsrsState: FsrsState) {
   return {
-    type: SrsType.FsrsFourPointFive,
+    kind: SrsKind.FsrsFourPointFive,
     stability: fsrsState.stability,
     difficulty: fsrsState.difficulty,
     nextReviewAt: fsrsState.nextReviewAt,
     prevReviewAt: fsrsState.prevReviewAt,
-  } satisfies SrsState;
+  } satisfies SrsStateType;
 }
 
 // This is a placeholder to keep code around that demonstrates how to support

--- a/projects/app/src/dictionary/dictionary.asset.json
+++ b/projects/app/src/dictionary/dictionary.asset.json
@@ -322,6 +322,7 @@
 ["作者:author",{"gloss":["author"],"pinyin":["zuò zhě"],"example":"他是这本书的作者。","partOfSpeech":"noun","definition":"A person who writes books, articles, or other literary works."}],
 ["你:you",{"gloss":["you"],"pinyin":["nǐ"],"example":"你好！","partOfSpeech":"pronoun","definition":"Used to address one or more people directly."}],
 ["你们:yall",{"gloss":["ya'll","you"],"pinyin":["nǐ men"],"example":"你们好。","partOfSpeech":"pronoun","definition":"Used to address two or more people directly."}],
+["你好:hello",{"gloss":["hello","hi"],"glossHint":null,"pinyin":["nǐ hǎo"],"example":"你好，很高兴见到你。","partOfSpeech":"interjection","componentFormOf":null,"visualVariants":null,"definition":"A common greeting used to say hello or hi."}],
 ["佥:together",{"gloss":["together"],"example":"我们佥同意这个决定。","partOfSpeech":"adverb","definition":"Refers to the concept of being together or unanimous, often used in contexts where agreement or collective action is involved."}],
 ["使:cause",{"gloss":["cause","make"],"pinyin":["shǐ"],"example":"这部电影使我感动。","partOfSpeech":"verb","definition":"To make something happen, often with an effect or outcome."}],
 ["使用:use",{"gloss":["use","employ"],"pinyin":["shǐ yòng"],"example":"请使用这个工具。","partOfSpeech":"verb","definition":"To make practical use of something."}],

--- a/projects/app/src/dictionary/dictionary.ts
+++ b/projects/app/src/dictionary/dictionary.ts
@@ -669,7 +669,7 @@ export async function decomposeHanzi(
         const idsNode = parseIds(ids);
         for (const leaf of walkIdsNode(idsNode)) {
           if (
-            leaf.type === `LeafCharacter` &&
+            leaf.operator === `LeafCharacter` &&
             leaf.character !== char // todo turn into invariant?
           ) {
             result.push(leaf.character);

--- a/projects/app/src/server/lib/inngest.ts
+++ b/projects/app/src/server/lib/inngest.ts
@@ -1,4 +1,4 @@
-import { hanziWordSkillTypes } from "@/data/model";
+import { hanziWordSkillKinds } from "@/data/model";
 import { v7 } from "@/data/rizzleSchema";
 import { hanziWordSkill } from "@/data/skills";
 import {
@@ -404,7 +404,7 @@ const migrateHanziWords = inngest.createFunction(
       ([oldHanziWord, newHanziWord]) =>
         newHanziWord == null // `null` indicates a deletion rather than a rename, so skip these.
           ? []
-          : hanziWordSkillTypes.map(
+          : hanziWordSkillKinds.map(
               (skillType) =>
                 [
                   hanziWordSkill(skillType, oldHanziWord),
@@ -417,7 +417,7 @@ const migrateHanziWords = inngest.createFunction(
       ([oldHanziWord, newHanziWord]) =>
         // When newHanziWord is null it's a deletion rather than a rename.
         newHanziWord == null
-          ? hanziWordSkillTypes.map((skillType) =>
+          ? hanziWordSkillKinds.map((skillType) =>
               hanziWordSkill(skillType, oldHanziWord),
             )
           : [],

--- a/projects/app/src/server/lib/queries.ts
+++ b/projects/app/src/server/lib/queries.ts
@@ -1,5 +1,5 @@
-import type { SrsState } from "@/data/model";
-import { SrsType } from "@/data/model";
+import type { SrsStateType } from "@/data/model";
+import { SrsKind } from "@/data/model";
 import type { Skill } from "@/data/rizzleSchema";
 import type { FsrsState } from "@/util/fsrs";
 import { nextReview } from "@/util/fsrs";
@@ -37,9 +37,9 @@ export async function updateSkillState(
   // Save the new state.
   {
     const srs = {
-      type: SrsType.FsrsFourPointFive,
+      kind: SrsKind.FsrsFourPointFive,
       ...fsrsState,
-    } satisfies SrsState;
+    } satisfies SrsStateType;
 
     await tx
       .insert(schema.skillState)

--- a/projects/app/src/server/lib/replicache.ts
+++ b/projects/app/src/server/lib/replicache.ts
@@ -1,4 +1,4 @@
-import { MistakeType } from "@/data/model";
+import { MistakeKind } from "@/data/model";
 import type { SupportedSchema } from "@/data/rizzleSchema";
 import { rPinyinInitialGroupId, v7, v7_1 } from "@/data/rizzleSchema";
 import {
@@ -61,7 +61,7 @@ const mutators: RizzleDrizzleMutators<SupportedSchema, Drizzle> = {
       .values([{ id, userId, gloss, hanzi, createdAt: now }]);
 
     // Apply mistake effect to in-scope skills.
-    const mistake = { type: MistakeType.HanziGloss, gloss, hanzi } as const;
+    const mistake = { kind: MistakeKind.HanziGloss, gloss, hanzi } as const;
     const skillsToReview = await skillsToReReviewForHanziGlossMistake(mistake);
 
     // Find any existing skills for the user that should be reviewed again.
@@ -85,7 +85,7 @@ const mutators: RizzleDrizzleMutators<SupportedSchema, Drizzle> = {
       .values([{ id, userId, pinyin, hanzi, createdAt: now }]);
 
     // Apply mistake effect to in-scope skills.
-    const mistake = { type: MistakeType.HanziPinyin, pinyin, hanzi } as const;
+    const mistake = { kind: MistakeKind.HanziPinyin, pinyin, hanzi } as const;
     const skillsToReview = await skillsToReReviewForHanziPinyinMistake(mistake);
 
     // Find any existing skills for the user that should be reviewed again.

--- a/projects/app/test/client/query.test.ts
+++ b/projects/app/test/client/query.test.ts
@@ -4,7 +4,7 @@ import {
   targetSkillsReviewQueue,
 } from "#client/query.ts";
 import type { HanziText, PinyinText } from "#data/model.ts";
-import { QuestionFlagType, SrsType } from "#data/model.ts";
+import { QuestionFlagKind, SrsKind } from "#data/model.ts";
 import { v7Mutators } from "#data/rizzleMutators.ts";
 import type { Skill } from "#data/rizzleSchema.ts";
 import { v7 } from "#data/rizzleSchema.ts";
@@ -205,17 +205,17 @@ await test(`${flagsForSrsState.name} suite`, async () => {
   await test(`marks a question as new if it has no srs`, async () => {
     assert.deepEqual(
       flagsForSrsState({
-        type: SrsType.Mock,
+        kind: SrsKind.Mock,
         prevReviewAt: new Date(),
         nextReviewAt: new Date(),
       }),
-      { type: QuestionFlagType.NewSkill },
+      { kind: QuestionFlagKind.NewSkill },
     );
   });
 
   await test(`marks a question as new if it has fsrs state but is not stable enough to be introduced`, async () => {
     assert.deepEqual(flagsForSrsState(undefined), {
-      type: QuestionFlagType.NewSkill,
+      kind: QuestionFlagKind.NewSkill,
     });
   });
 });

--- a/projects/app/test/data/hanzi.test.ts
+++ b/projects/app/test/data/hanzi.test.ts
@@ -21,219 +21,219 @@ await test(`${flattenIds.name} handles ⿱⿱ to ⿳ and ⿰⿰ to ⿲`, () => {
 
 await test(`${parseIds.name} handles 1 depth`, () => {
   assert.deepEqual(parseIds(`木`), {
-    type: `LeafCharacter`,
+    operator: `LeafCharacter`,
     character: `木`,
   });
 
   // 相
   assert.deepEqual(parseIds(`⿰木目`), {
-    type: IdsOperator.LeftToRight,
-    left: { type: `LeafCharacter`, character: `木` },
-    right: { type: `LeafCharacter`, character: `目` },
+    operator: IdsOperator.LeftToRight,
+    left: { operator: `LeafCharacter`, character: `木` },
+    right: { operator: `LeafCharacter`, character: `目` },
   });
 
   // 杏
   assert.deepEqual(parseIds(`⿱木口`), {
-    type: IdsOperator.AboveToBelow,
-    above: { type: `LeafCharacter`, character: `木` },
-    below: { type: `LeafCharacter`, character: `口` },
+    operator: IdsOperator.AboveToBelow,
+    above: { operator: `LeafCharacter`, character: `木` },
+    below: { operator: `LeafCharacter`, character: `口` },
   });
 
   // 衍
   assert.deepEqual(parseIds(`⿲彳氵亍`), {
-    type: IdsOperator.LeftToMiddleToRight,
-    left: { type: `LeafCharacter`, character: `彳` },
-    middle: { type: `LeafCharacter`, character: `氵` },
-    right: { type: `LeafCharacter`, character: `亍` },
+    operator: IdsOperator.LeftToMiddleToRight,
+    left: { operator: `LeafCharacter`, character: `彳` },
+    middle: { operator: `LeafCharacter`, character: `氵` },
+    right: { operator: `LeafCharacter`, character: `亍` },
   });
 
   // 京
   assert.deepEqual(parseIds(`⿳亠口小`), {
-    type: IdsOperator.AboveToMiddleAndBelow,
-    above: { type: `LeafCharacter`, character: `亠` },
-    middle: { type: `LeafCharacter`, character: `口` },
-    below: { type: `LeafCharacter`, character: `小` },
+    operator: IdsOperator.AboveToMiddleAndBelow,
+    above: { operator: `LeafCharacter`, character: `亠` },
+    middle: { operator: `LeafCharacter`, character: `口` },
+    below: { operator: `LeafCharacter`, character: `小` },
   });
 
   // 回
   assert.deepEqual(parseIds(`⿴囗口`), {
-    type: IdsOperator.FullSurround,
-    surrounding: { type: `LeafCharacter`, character: `囗` },
-    surrounded: { type: `LeafCharacter`, character: `口` },
+    operator: IdsOperator.FullSurround,
+    surrounding: { operator: `LeafCharacter`, character: `囗` },
+    surrounded: { operator: `LeafCharacter`, character: `口` },
   });
 
   // 凰
   assert.deepEqual(parseIds(`⿵几皇`), {
-    type: IdsOperator.SurroundFromAbove,
-    above: { type: `LeafCharacter`, character: `几` },
-    surrounded: { type: `LeafCharacter`, character: `皇` },
+    operator: IdsOperator.SurroundFromAbove,
+    above: { operator: `LeafCharacter`, character: `几` },
+    surrounded: { operator: `LeafCharacter`, character: `皇` },
   });
 
   // 凶
   assert.deepEqual(parseIds(`⿶凵㐅`), {
-    type: IdsOperator.SurroundFromBelow,
-    below: { type: `LeafCharacter`, character: `凵` },
-    surrounded: { type: `LeafCharacter`, character: `㐅` },
+    operator: IdsOperator.SurroundFromBelow,
+    below: { operator: `LeafCharacter`, character: `凵` },
+    surrounded: { operator: `LeafCharacter`, character: `㐅` },
   });
 
   // 匠
   assert.deepEqual(parseIds(`⿷匚斤`), {
-    type: IdsOperator.SurroundFromLeft,
-    left: { type: `LeafCharacter`, character: `匚` },
-    surrounded: { type: `LeafCharacter`, character: `斤` },
+    operator: IdsOperator.SurroundFromLeft,
+    left: { operator: `LeafCharacter`, character: `匚` },
+    surrounded: { operator: `LeafCharacter`, character: `斤` },
   });
 
   // 㕚
   assert.deepEqual(parseIds(`⿼叉丶`), {
-    type: IdsOperator.SurroundFromRight,
-    right: { type: `LeafCharacter`, character: `叉` },
-    surrounded: { type: `LeafCharacter`, character: `丶` },
+    operator: IdsOperator.SurroundFromRight,
+    right: { operator: `LeafCharacter`, character: `叉` },
+    surrounded: { operator: `LeafCharacter`, character: `丶` },
   });
 
   // 病
   assert.deepEqual(parseIds(`⿸疒丙`), {
-    type: IdsOperator.SurroundFromUpperLeft,
-    upperLeft: { type: `LeafCharacter`, character: `疒` },
-    surrounded: { type: `LeafCharacter`, character: `丙` },
+    operator: IdsOperator.SurroundFromUpperLeft,
+    upperLeft: { operator: `LeafCharacter`, character: `疒` },
+    surrounded: { operator: `LeafCharacter`, character: `丙` },
   });
 
   // 戒
   assert.deepEqual(parseIds(`⿹戈廾`), {
-    type: IdsOperator.SurroundFromUpperRight,
-    upperRight: { type: `LeafCharacter`, character: `戈` },
-    surrounded: { type: `LeafCharacter`, character: `廾` },
+    operator: IdsOperator.SurroundFromUpperRight,
+    upperRight: { operator: `LeafCharacter`, character: `戈` },
+    surrounded: { operator: `LeafCharacter`, character: `廾` },
   });
 
   // 超
   assert.deepEqual(parseIds(`⿺走召`), {
-    type: IdsOperator.SurroundFromLowerLeft,
-    lowerLeft: { type: `LeafCharacter`, character: `走` },
-    surrounded: { type: `LeafCharacter`, character: `召` },
+    operator: IdsOperator.SurroundFromLowerLeft,
+    lowerLeft: { operator: `LeafCharacter`, character: `走` },
+    surrounded: { operator: `LeafCharacter`, character: `召` },
   });
 
   // 氷
   assert.deepEqual(parseIds(`⿽水丶`), {
-    type: IdsOperator.SurroundFromLowerRight,
-    lowerRight: { type: `LeafCharacter`, character: `水` },
-    surrounded: { type: `LeafCharacter`, character: `丶` },
+    operator: IdsOperator.SurroundFromLowerRight,
+    lowerRight: { operator: `LeafCharacter`, character: `水` },
+    surrounded: { operator: `LeafCharacter`, character: `丶` },
   });
 
   // 巫
   assert.deepEqual(parseIds(`⿻工从`), {
-    type: IdsOperator.Overlaid,
-    overlay: { type: `LeafCharacter`, character: `工` },
-    underlay: { type: `LeafCharacter`, character: `从` },
+    operator: IdsOperator.Overlaid,
+    overlay: { operator: `LeafCharacter`, character: `工` },
+    underlay: { operator: `LeafCharacter`, character: `从` },
   });
 
   // 卐
   assert.deepEqual(parseIds(`⿾卍`), {
-    type: IdsOperator.HorizontalReflection,
-    reflected: { type: `LeafCharacter`, character: `卍` },
+    operator: IdsOperator.HorizontalReflection,
+    reflected: { operator: `LeafCharacter`, character: `卍` },
   });
 
   // 𠕄
   assert.deepEqual(parseIds(`⿿凹`), {
-    type: IdsOperator.Rotation,
-    rotated: { type: `LeafCharacter`, character: `凹` },
+    operator: IdsOperator.Rotation,
+    rotated: { operator: `LeafCharacter`, character: `凹` },
   });
 
   assert.deepEqual(parseIds(`①`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 1,
   });
 
   assert.deepEqual(parseIds(`②`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 2,
   });
 
   assert.deepEqual(parseIds(`③`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 3,
   });
 
   assert.deepEqual(parseIds(`④`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 4,
   });
 
   assert.deepEqual(parseIds(`⑤`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 5,
   });
 
   assert.deepEqual(parseIds(`⑥`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 6,
   });
 
   assert.deepEqual(parseIds(`⑦`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 7,
   });
 
   assert.deepEqual(parseIds(`⑧`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 8,
   });
 
   assert.deepEqual(parseIds(`⑨`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 9,
   });
 
   assert.deepEqual(parseIds(`⑩`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 10,
   });
 
   assert.deepEqual(parseIds(`⑪`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 11,
   });
 
   assert.deepEqual(parseIds(`⑫`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 12,
   });
 
   assert.deepEqual(parseIds(`⑬`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 13,
   });
 
   assert.deepEqual(parseIds(`⑭`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 14,
   });
 
   assert.deepEqual(parseIds(`⑮`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 15,
   });
 
   assert.deepEqual(parseIds(`⑯`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 16,
   });
 
   assert.deepEqual(parseIds(`⑰`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 17,
   });
 
   assert.deepEqual(parseIds(`⑱`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 18,
   });
 
   assert.deepEqual(parseIds(`⑲`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 19,
   });
 
   assert.deepEqual(parseIds(`⑳`), {
-    type: `LeafUnknownCharacter`,
+    operator: `LeafUnknownCharacter`,
     strokeCount: 20,
   });
 });
@@ -242,12 +242,12 @@ await test(`${parseIds.name} handles 2 depth`, () => {
   {
     const cursor = { index: 0 };
     assert.deepEqual(parseIds(`⿰a⿱bc`, cursor), {
-      type: IdsOperator.LeftToRight,
-      left: { type: `LeafCharacter`, character: `a` },
+      operator: IdsOperator.LeftToRight,
+      left: { operator: `LeafCharacter`, character: `a` },
       right: {
-        type: IdsOperator.AboveToBelow,
-        above: { type: `LeafCharacter`, character: `b` },
-        below: { type: `LeafCharacter`, character: `c` },
+        operator: IdsOperator.AboveToBelow,
+        above: { operator: `LeafCharacter`, character: `b` },
+        below: { operator: `LeafCharacter`, character: `c` },
       },
     });
     assert.deepEqual(cursor, { index: 5 });
@@ -256,16 +256,16 @@ await test(`${parseIds.name} handles 2 depth`, () => {
   {
     const cursor = { index: 0 };
     assert.deepEqual(parseIds(`⿱a⿳bc⿴de`, cursor), {
-      type: IdsOperator.AboveToBelow,
-      above: { type: `LeafCharacter`, character: `a` },
+      operator: IdsOperator.AboveToBelow,
+      above: { operator: `LeafCharacter`, character: `a` },
       below: {
-        type: IdsOperator.AboveToMiddleAndBelow,
-        above: { type: `LeafCharacter`, character: `b` },
-        middle: { type: `LeafCharacter`, character: `c` },
+        operator: IdsOperator.AboveToMiddleAndBelow,
+        above: { operator: `LeafCharacter`, character: `b` },
+        middle: { operator: `LeafCharacter`, character: `c` },
         below: {
-          type: IdsOperator.FullSurround,
-          surrounding: { type: `LeafCharacter`, character: `d` },
-          surrounded: { type: `LeafCharacter`, character: `e` },
+          operator: IdsOperator.FullSurround,
+          surrounding: { operator: `LeafCharacter`, character: `d` },
+          surrounded: { operator: `LeafCharacter`, character: `e` },
         },
       },
     });
@@ -275,9 +275,9 @@ await test(`${parseIds.name} handles 2 depth`, () => {
 
 await test(`${parseIds.name} regression tests`, () => {
   assert.deepEqual(parseIds(`⿱丿𭕄`), {
-    type: IdsOperator.AboveToBelow,
-    above: { type: `LeafCharacter`, character: `丿` },
-    below: { type: `LeafCharacter`, character: `𭕄` },
+    operator: IdsOperator.AboveToBelow,
+    above: { operator: `LeafCharacter`, character: `丿` },
+    below: { operator: `LeafCharacter`, character: `𭕄` },
   });
 });
 
@@ -285,7 +285,7 @@ await test(`${walkIdsNode.name} fixture`, () => {
   const ids = parseIds(`⿰a⿱bc`);
 
   const leafs = [...walkIdsNode(ids)].map((x) => {
-    switch (x.type) {
+    switch (x.operator) {
       case `LeafCharacter`: {
         return x.character;
       }

--- a/projects/app/test/data/helpers.ts
+++ b/projects/app/test/data/helpers.ts
@@ -1,5 +1,8 @@
-import type { SrsStateFsrsFourPointFive, SrsStateMock } from "#data/model.ts";
-import { SrsType } from "#data/model.ts";
+import type {
+  SrsStateFsrsFourPointFiveType,
+  SrsStateMockType,
+} from "#data/model.ts";
+import { SrsKind } from "#data/model.ts";
 import type { Rating } from "#util/fsrs.ts";
 import { nextReview } from "#util/fsrs.ts";
 import { invariant } from "@haohaohow/lib/invariant";
@@ -66,9 +69,9 @@ export const parseRelativeTimeShorthand = (
 export const mockSrsState = (
   prevReviewAt: Date,
   nextReviewAt: Date,
-): SrsStateMock => {
+): SrsStateMockType => {
   return {
-    type: SrsType.Mock,
+    kind: SrsKind.Mock,
     prevReviewAt,
     nextReviewAt,
   };
@@ -78,7 +81,7 @@ export const fsrsSrsState = (
   prevReviewAt: Date,
   nextReviewAt: Date,
   rating: Rating,
-): SrsStateFsrsFourPointFive => {
+): SrsStateFsrsFourPointFiveType => {
   let state = null;
   for (const now of [时`-20d`, 时`-15d`, 时`-10d`, 时`-5d`, 时`-2d`]) {
     state = nextReview(state, rating, now);
@@ -86,7 +89,7 @@ export const fsrsSrsState = (
   invariant(state != null);
 
   return {
-    type: SrsType.FsrsFourPointFive,
+    kind: SrsKind.FsrsFourPointFive,
     prevReviewAt,
     nextReviewAt,
     stability: state.stability,

--- a/projects/app/test/data/rizzleSchema.test.ts
+++ b/projects/app/test/data/rizzleSchema.test.ts
@@ -1,5 +1,5 @@
-import { SkillType } from "#data/model.ts";
-import { rSkill, rSkillType } from "#data/rizzleSchema.ts";
+import { SkillKind } from "#data/model.ts";
+import { rSkill, rSkillKind } from "#data/rizzleSchema.ts";
 import { hanziWordToGloss } from "#data/skills.ts";
 import { r } from "#util/rizzle.ts";
 import assert from "node:assert/strict";
@@ -61,36 +61,36 @@ await test(`skill as key`, async (t) => {
   }
 });
 
-await test(`${rSkillType.name}()`, async (t) => {
+await test(`${rSkillKind.name}()`, async (t) => {
   const posts = r.entity(`foo/[id]`, {
     id: r.string(),
-    skill: rSkillType(),
+    skill: rSkillKind(),
   });
 
   // Marshal and unmarshal round tripping
-  for (const skillType of [
-    SkillType.Deprecated_EnglishToRadical,
-    SkillType.Deprecated_PinyinToRadical,
-    SkillType.Deprecated_RadicalToEnglish,
-    SkillType.Deprecated_RadicalToPinyin,
-    SkillType.Deprecated,
-    SkillType.GlossToHanziWord,
-    SkillType.HanziWordToGloss,
-    SkillType.HanziWordToPinyin,
-    SkillType.HanziWordToPinyinFinal,
-    SkillType.HanziWordToPinyinInitial,
-    SkillType.HanziWordToPinyinTone,
-    SkillType.ImageToHanziWord,
-    SkillType.PinyinToHanziWord,
+  for (const skillKind of [
+    SkillKind.Deprecated_EnglishToRadical,
+    SkillKind.Deprecated_PinyinToRadical,
+    SkillKind.Deprecated_RadicalToEnglish,
+    SkillKind.Deprecated_RadicalToPinyin,
+    SkillKind.Deprecated,
+    SkillKind.GlossToHanziWord,
+    SkillKind.HanziWordToGloss,
+    SkillKind.HanziWordToPinyin,
+    SkillKind.HanziWordToPinyinFinal,
+    SkillKind.HanziWordToPinyinInitial,
+    SkillKind.HanziWordToPinyinTone,
+    SkillKind.ImageToHanziWord,
+    SkillKind.PinyinToHanziWord,
   ] as const) {
     using tx = makeMockTx(t);
 
-    await posts.set(tx, { id: `1` }, { id: `1`, skill: skillType });
+    await posts.set(tx, { id: `1` }, { id: `1`, skill: skillKind });
     const [, marshaledData] = tx.set.mock.calls[0]!.arguments;
     tx.get.mock.mockImplementationOnce(async () => marshaledData);
     assert.deepEqual(await posts.get(tx, { id: `1` }), {
       id: `1`,
-      skill: skillType,
+      skill: skillKind,
     });
   }
 });

--- a/projects/app/test/data/skills.test.ts
+++ b/projects/app/test/data/skills.test.ts
@@ -1,12 +1,12 @@
-import { SkillType } from "#data/model.ts";
+import { SkillKind } from "#data/model.ts";
 import type { Skill } from "#data/rizzleSchema.ts";
 import type { SkillLearningGraph } from "#data/skills.ts";
 import {
   computeSkillRating,
   hanziWordToGloss,
+  skillKindFromSkill,
   skillLearningGraph,
   skillReviewQueue,
-  skillTypeFromSkill,
 } from "#data/skills.ts";
 import {
   allHsk1HanziWords,
@@ -383,7 +383,7 @@ await test(`${skillReviewQueue.name} suite`, async () => {
     });
   });
 
-  await test(`${SkillType.HanziWordToGloss} skills`, async () => {
+  await test(`${SkillKind.HanziWordToGloss} skills`, async () => {
     await test(`works for 好`, async () => {
       const graph = await skillLearningGraph({
         targetSkills: [`he:好:good`],
@@ -600,7 +600,7 @@ await test(`${skillReviewQueue.name} suite`, async () => {
     });
   });
 
-  await test(`${SkillType.HanziWordToPinyin} skills`, async () => {
+  await test(`${SkillKind.HanziWordToPinyin} skills`, async () => {
     await test(`doesn't learn pinyin for all constituents of a single character`, async () => {
       const graph = await skillLearningGraph({ targetSkills: [`hp:好:good`] });
       expect(
@@ -633,7 +633,7 @@ await test(`${skillReviewQueue.name} suite`, async () => {
       });
 
       const isHpSkill = (s: Skill) =>
-        skillTypeFromSkill(s) === SkillType.HanziWordToPinyin;
+        skillKindFromSkill(s) === SkillKind.HanziWordToPinyin;
 
       const onlyHpQueue = {
         items: queue.items.filter((s) => isHpSkill(s)),
@@ -757,7 +757,7 @@ await test(`${computeSkillRating.name} suite`, async () => {
     expect(rating).toMatchObject({ skill, durationMs });
   });
 
-  await test(`${SkillType.HanziWordToGloss} suites`, async () => {
+  await test(`${SkillKind.HanziWordToGloss} suites`, async () => {
     const skill = `he:我:i`;
 
     await test(`gives rating based on duration`, async () => {

--- a/projects/app/test/dictionary/dictionary.test.ts
+++ b/projects/app/test/dictionary/dictionary.test.ts
@@ -471,7 +471,7 @@ await test(`expect missing glyphs to be included decomposition data`, async () =
     );
     const idsNode = parseIds(ids);
     for (const leaf of walkIdsNode(idsNode)) {
-      if (leaf.type === `LeafCharacter`) {
+      if (leaf.operator === `LeafCharacter`) {
         allComponents.add(leaf.character);
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new question type: Hanzi-to-Pinyin, including a new UI component and dictionary entry for "你好" (hello).

- **Refactor**
  - Standardized naming conventions throughout the app, replacing `type` with `kind` for skill, question, mistake, and SRS entities.
  - Updated all related enums and helper functions from `Type` to `Kind` (e.g., `SkillType` → `SkillKind`).
  - Adjusted discriminant property names in data structures and UI components for consistency.

- **Bug Fixes**
  - Corrected property checks in Hanzi decomposition logic from `type` to `operator` to ensure accurate parsing and glyph handling.

- **Documentation**
  - Added and updated documentation to clarify code conventions and terminology, including guidance on discriminated unions.

- **Tests**
  - Updated test cases to align with new naming conventions and property changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->