### PR TITLE
delete unnecessary flex-col classes

### DIFF
--- a/projects/app/eslint.config.mjs
+++ b/projects/app/eslint.config.mjs
@@ -269,6 +269,15 @@ export default tseslint.config(
       // @haohaohow/eslint-rules
       //
       "@haohaohow/reanimated-default-name": `error`,
+      "@haohaohow/no-restricted-css-classes": [
+        `error`,
+        {
+          classes: [
+            // eslint-disable-next-line @haohaohow/no-restricted-css-classes
+            { name: `flex-col`, message: `flex-col is already the default` },
+          ],
+        },
+      ],
 
       //
       // tailwindcss

--- a/projects/app/src/app/(sidenav)/explore/(mnemonics)/mnemonics/index.tsx
+++ b/projects/app/src/app/(sidenav)/explore/(mnemonics)/mnemonics/index.tsx
@@ -102,7 +102,7 @@ export default function MnemonicsPage() {
           )
         ) : (
           <>
-            <View className="">
+            <View>
               <Text className="text-lg font-bold text-body">Tones</Text>
             </View>
             <View className="flex-row flex-wrap gap-3.5 lg:gap-4">
@@ -129,7 +129,7 @@ export default function MnemonicsPage() {
 
             <View className="border-t-2 border-primary-5"></View>
 
-            <View className="">
+            <View>
               <Text className="text-lg font-bold text-body">Initials</Text>
             </View>
 
@@ -182,7 +182,7 @@ export default function MnemonicsPage() {
 
             <View className="border-t-2 border-primary-5"></View>
 
-            <View className="">
+            <View>
               <Text className="text-lg font-bold text-body">Finals</Text>
             </View>
             <View className="flex-row flex-wrap gap-3.5 lg:gap-4">

--- a/projects/app/src/app/(sidenav)/explore/(radicals)/radicals/[id].tsx
+++ b/projects/app/src/app/(sidenav)/explore/(radicals)/radicals/[id].tsx
@@ -46,7 +46,7 @@ export default function RadicalPage() {
             <>
               {query.data?.nameMnemonics == null ? null : (
                 <ReferencePageBodySection title="Name mnemonics">
-                  <View className="flex-col gap-2">
+                  <View className="gap-2">
                     {query.data.nameMnemonics.map(
                       ({ mnemonic, rationale }, i) => (
                         <View key={i} className="gap-1">
@@ -62,7 +62,7 @@ export default function RadicalPage() {
               )}
               {query.data?.pinyinMnemonics == null ? null : (
                 <ReferencePageBodySection title="Pinyin mnemonics">
-                  <View className="flex-col gap-2">
+                  <View className="gap-2">
                     {query.data.pinyinMnemonics.map(
                       ({ mnemonic, strategy: rationale }, i) => (
                         <View key={i} className="gap-1">

--- a/projects/app/src/app/(sidenav)/explore/(radicals)/radicals/new/[id].tsx
+++ b/projects/app/src/app/(sidenav)/explore/(radicals)/radicals/new/[id].tsx
@@ -143,7 +143,7 @@ export default function RadicalPage() {
         <View className="h-1 w-2 flex-1"></View>
         <View className="h-1 w-2 flex-1"></View>
 
-        <View className="w-full max-w-[600px] flex-col items-stretch gap-3 mb-safe-offset-2">
+        <View className="w-full max-w-[600px] items-stretch gap-3 mb-safe-offset-2">
           <RectButton2
             variant="outline"
             onPress={() => {
@@ -304,7 +304,7 @@ export default function RadicalPage() {
                 <>
                   {query.data?.nameMnemonics == null ? null : (
                     <ReferencePageBodySection title="Mnemonics">
-                      <View className="flex-col gap-2">
+                      <View className="gap-2">
                         {query.data.nameMnemonics.map(
                           ({ mnemonic, rationale }, i) => (
                             <View key={i} className="gap-1">

--- a/projects/app/src/app/(sidenav)/learn/history/index.tsx
+++ b/projects/app/src/app/(sidenav)/learn/history/index.tsx
@@ -109,7 +109,7 @@ export default function HistoryPage() {
             <Text className="text-xl text-body">queue items</Text>
 
             {data2Query.data?.items.slice(0, 100).map((skill, i) => (
-              <View key={i} className="flex-col items-center">
+              <View key={i} className="items-center">
                 <SkillRefText skill={skill} context="body" />
                 <Text className="hhh-text-caption">
                   {skillKindToShorthand(skillKindFromSkill(skill))}
@@ -132,7 +132,7 @@ export default function HistoryPage() {
           <View>
             <Text className="self-center text-xl text-body">history</Text>
 
-            <View className="flex-col gap-2">
+            <View className="gap-2">
               {skillRatingsQuery.data?.map(([_key, value], i) => {
                 const { skill, createdAt } = value;
                 return (

--- a/projects/app/src/app/(website)/_layout.web.tsx
+++ b/projects/app/src/app/(website)/_layout.web.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @haohaohow/no-restricted-css-classes */
 import { RectButton2 } from "@/client/ui/RectButton2";
 import { useWebsiteStore } from "@/client/website";
 import { invariant } from "@haohaohow/lib/invariant";

--- a/projects/app/src/app/(website)/index.web.tsx
+++ b/projects/app/src/app/(website)/index.web.tsx
@@ -20,7 +20,7 @@ export default function WebsitePage() {
 
   return (
     <>
-      <View className="www-px-comfortable mb-[100px] h-screen flex-col items-center justify-center pt-[100px]">
+      <View className="www-px-comfortable mb-[100px] h-screen items-center justify-center pt-[100px]">
         <View className="mb-[100px] items-center">
           <Text className="www-text-hero text-center lg:text-left">
             Teach yourself Chinese.

--- a/projects/app/src/app/dev/ui.tsx
+++ b/projects/app/src/app/dev/ui.tsx
@@ -450,41 +450,47 @@ const RectButton2Examples = (props: Partial<PropsOf<typeof RectButton2>>) => (
       </ExampleStack>
     </View>
 
-    <LittlePrimaryHeader title="flex-col" />
+    <LittlePrimaryHeader
+      // eslint-disable-next-line @haohaohow/no-restricted-css-classes
+      title="flex-col"
+    />
 
     <View className="flex-row flex-wrap">
       <ExampleStack title="items-start" showFrame>
-        <View className="w-[120px] flex-col items-start gap-2">
+        <View className="w-[120px] items-start gap-2">
           <RectButton2Variants {...props} />
         </View>
       </ExampleStack>
 
       <ExampleStack title="items-center" showFrame>
-        <View className="w-[120px] flex-col items-center gap-2">
+        <View className="w-[120px] items-center gap-2">
           <RectButton2Variants {...props} />
         </View>
       </ExampleStack>
 
       <ExampleStack title="items-stretch" showFrame>
-        <View className="w-[120px] flex-col items-stretch gap-2">
-          <RectButton2Variants className="flex-col" {...props} />
+        <View className="w-[120px] items-stretch gap-2">
+          <RectButton2Variants {...props} />
         </View>
       </ExampleStack>
 
       <ExampleStack title="items-end" showFrame>
-        <View className="w-[120px] flex-col items-end gap-2">
+        <View className="w-[120px] items-end gap-2">
           <RectButton2Variants {...props} />
         </View>
       </ExampleStack>
     </View>
 
-    <LittlePrimaryHeader title="flex-col + flex-1" />
+    <LittlePrimaryHeader
+      // eslint-disable-next-line @haohaohow/no-restricted-css-classes
+      title="flex-col + flex-1"
+    />
 
     <View className="flex-row flex-wrap">
       <ExampleStack
         title="items-start"
         showFrame
-        childrenClassName="w-[120px] flex-col items-start gap-2"
+        childrenClassName="w-[120px] items-start gap-2"
       >
         <RectButton2Variants className="flex-1" {...props} />
       </ExampleStack>
@@ -492,7 +498,7 @@ const RectButton2Examples = (props: Partial<PropsOf<typeof RectButton2>>) => (
       <ExampleStack
         title="items-center"
         showFrame
-        childrenClassName="w-[120px] flex-col items-center gap-2"
+        childrenClassName="w-[120px] items-center gap-2"
       >
         <RectButton2Variants className="flex-1" {...props} />
       </ExampleStack>
@@ -500,7 +506,7 @@ const RectButton2Examples = (props: Partial<PropsOf<typeof RectButton2>>) => (
       <ExampleStack
         title="items-stretch"
         showFrame
-        childrenClassName="w-[120px] flex-col items-stretch gap-2"
+        childrenClassName="w-[120px] items-stretch gap-2"
       >
         <RectButton2Variants className="flex-1" {...props} />
       </ExampleStack>
@@ -508,7 +514,7 @@ const RectButton2Examples = (props: Partial<PropsOf<typeof RectButton2>>) => (
       <ExampleStack
         title="items-end"
         showFrame
-        childrenClassName="w-[120px] flex-col items-end gap-2"
+        childrenClassName="w-[120px] items-end gap-2"
       >
         <RectButton2Variants className="flex-1" {...props} />
       </ExampleStack>
@@ -625,13 +631,16 @@ const TextAnswerButtonExamples = (
       </ExampleStack>
     </View>
 
-    <LittlePrimaryHeader title="flex-col" />
+    <LittlePrimaryHeader
+      // eslint-disable-next-line @haohaohow/no-restricted-css-classes
+      title="flex-col"
+    />
 
     <View className="flex-row flex-wrap">
       <ExampleStack
         title="items-start"
         showFrame
-        childrenClassName="size-[120px] flex-col items-start gap-2"
+        childrenClassName="size-[120px] items-start gap-2"
       >
         <SyncedAnswerButtonExample />
       </ExampleStack>
@@ -639,7 +648,7 @@ const TextAnswerButtonExamples = (
       <ExampleStack
         title="items-center"
         showFrame
-        childrenClassName="size-[120px] flex-col items-center gap-2"
+        childrenClassName="size-[120px] items-center gap-2"
       >
         <SyncedAnswerButtonExample />
       </ExampleStack>
@@ -647,7 +656,7 @@ const TextAnswerButtonExamples = (
       <ExampleStack
         title="items-stretch"
         showFrame
-        childrenClassName="size-[120px] flex-col gap-2"
+        childrenClassName="size-[120px] gap-2"
       >
         <SyncedAnswerButtonExample />
       </ExampleStack>
@@ -655,19 +664,22 @@ const TextAnswerButtonExamples = (
       <ExampleStack
         title="items-end"
         showFrame
-        childrenClassName="size-[120px] flex-col items-end gap-2"
+        childrenClassName="size-[120px] items-end gap-2"
       >
         <SyncedAnswerButtonExample />
       </ExampleStack>
     </View>
 
-    <LittlePrimaryHeader title="flex-col + flex-1" />
+    <LittlePrimaryHeader
+      // eslint-disable-next-line @haohaohow/no-restricted-css-classes
+      title="flex-col + flex-1"
+    />
 
     <View className="flex-row flex-wrap">
       <ExampleStack
         title="items-start"
         showFrame
-        childrenClassName="size-[120px] flex-col items-start gap-2"
+        childrenClassName="size-[120px] items-start gap-2"
       >
         <SyncedAnswerButtonExample className="flex-1" />
       </ExampleStack>
@@ -675,7 +687,7 @@ const TextAnswerButtonExamples = (
       <ExampleStack
         title="items-center"
         showFrame
-        childrenClassName="size-[120px] flex-col items-center gap-2"
+        childrenClassName="size-[120px] items-center gap-2"
       >
         <SyncedAnswerButtonExample className="flex-1" />
       </ExampleStack>
@@ -683,7 +695,7 @@ const TextAnswerButtonExamples = (
       <ExampleStack
         title="items-stretch"
         showFrame
-        childrenClassName="size-[120px] flex-col gap-2"
+        childrenClassName="size-[120px] gap-2"
       >
         <SyncedAnswerButtonExample className="flex-1" />
       </ExampleStack>
@@ -691,7 +703,7 @@ const TextAnswerButtonExamples = (
       <ExampleStack
         title="items-end"
         showFrame
-        childrenClassName="size-[120px] flex-col items-end gap-2"
+        childrenClassName="size-[120px] items-end gap-2"
       >
         <SyncedAnswerButtonExample className="flex-1" />
       </ExampleStack>
@@ -814,7 +826,7 @@ function QuizProgressBarExample() {
   }, [quizProgress]);
 
   return (
-    <View className="w-full flex-col gap-2">
+    <View className="w-full gap-2">
       <View className="min-h-[32px]">
         <QuizProgressBar progress={quizProgress.progress} />
       </View>
@@ -904,22 +916,22 @@ function PinyinOptionButtonExample() {
         title="default"
         childrenClassName="flex-row flex-wrap gap-1"
       >
-        <PinyinOptionButton text="nī" shortcutKey="1" />
-        <PinyinOptionButton text="ní" shortcutKey="2" />
-        <PinyinOptionButton text="nǐ" shortcutKey="3" />
-        <PinyinOptionButton text="nì" shortcutKey="4" />
-        <PinyinOptionButton text="ni" shortcutKey="5" />
+        <PinyinOptionButton pinyin="nī" shortcutKey="1" />
+        <PinyinOptionButton pinyin="ní" shortcutKey="2" />
+        <PinyinOptionButton pinyin="nǐ" shortcutKey="3" />
+        <PinyinOptionButton pinyin="nì" shortcutKey="4" />
+        <PinyinOptionButton pinyin="ni" shortcutKey="5" />
       </ExampleStack>
 
       <ExampleStack
         title="disabled"
         childrenClassName="flex-row flex-wrap gap-1"
       >
-        <PinyinOptionButton text="nī" shortcutKey="1" disabled />
-        <PinyinOptionButton text="ní" shortcutKey="2" disabled />
-        <PinyinOptionButton text="nǐ" shortcutKey="3" disabled />
-        <PinyinOptionButton text="nì" shortcutKey="4" disabled />
-        <PinyinOptionButton text="ni" shortcutKey="5" disabled />
+        <PinyinOptionButton pinyin="nī" shortcutKey="1" disabled />
+        <PinyinOptionButton pinyin="ní" shortcutKey="2" disabled />
+        <PinyinOptionButton pinyin="nǐ" shortcutKey="3" disabled />
+        <PinyinOptionButton pinyin="nì" shortcutKey="4" disabled />
+        <PinyinOptionButton pinyin="ni" shortcutKey="5" disabled />
       </ExampleStack>
     </View>
   );
@@ -929,7 +941,7 @@ function QuizDeckHanziToPinyinQuestionExample() {
     <QuizDeckHanziToPinyinQuestion
       question={{
         kind: QuestionKind.HanziToPinyin,
-        prompt: `Prompt text`,
+        prompt: `What sound does this make?`,
         answer: [
           [`你` as HanziChar, `nǐ`],
           [`好` as HanziChar, `hǎo`],

--- a/projects/app/src/client/ui/PinyinOptionButton.tsx
+++ b/projects/app/src/client/ui/PinyinOptionButton.tsx
@@ -4,18 +4,18 @@ import type { PropsOf } from "./types";
 
 interface PinyinOptionButtonProps
   extends Omit<PropsOf<typeof RectButton2>, `variant` | `children`> {
-  text: string;
+  pinyin: string;
   shortcutKey: string;
 }
 
 export function PinyinOptionButton({
-  text,
+  pinyin,
   shortcutKey,
   ...props
 }: PinyinOptionButtonProps) {
   return (
     <RectButton2 variant="option" className="flex-row gap-2" {...props}>
-      <Text className="hhh-text-button-option">{text}</Text>
+      <Text className="hhh-text-button-option">{pinyin}</Text>
       <Text className="hhh-text-caption">{shortcutKey}</Text>
     </RectButton2>
   );

--- a/projects/app/src/client/ui/QuizDeckHanziToPinyinQuestion.tsx
+++ b/projects/app/src/client/ui/QuizDeckHanziToPinyinQuestion.tsx
@@ -28,7 +28,9 @@ import z from "zod/v4";
 import { HanziWordRefText } from "./HanziWordRefText";
 import { Hhhmark } from "./Hhhmark";
 import { NewSkillModal } from "./NewSkillModal";
+import { PinyinOptionButton } from "./PinyinOptionButton";
 import { RectButton2 } from "./RectButton2";
+import { TextInputSingle } from "./TextInputSingle";
 import type { PropsOf } from "./types";
 
 export function QuizDeckHanziToPinyinQuestion({
@@ -39,9 +41,9 @@ export function QuizDeckHanziToPinyinQuestion({
   onNext: () => void;
   onRating: (ratings: NewSkillRating[], mistakes: MistakeType[]) => void;
 }) {
-  const { prompt, skill, flag } = question;
+  const { prompt, skill, flag, answer } = question;
 
-  const isCorrect = false as boolean | null;
+  const isCorrect = null as boolean | null;
 
   const handleSubmit = () => {
     onNext();
@@ -110,7 +112,27 @@ export function QuizDeckHanziToPinyinQuestion({
       <View>
         <Text className="text-xl font-bold text-body">{prompt}</Text>
       </View>
-      <View className="flex-1 justify-center py-quiz-px"></View>
+      <View className="flex-1 justify-center py-quiz-px">
+        <View className="flex-row justify-center gap-2">
+          {answer.map(([hanzi], i) => (
+            <View key={i} className="items-center gap-2">
+              <Text className="text-[80px] font-medium text-body">{hanzi}</Text>
+              <View className="h-[40px] w-[60px] rounded-xl border-2 border-dashed border-body/50"></View>
+            </View>
+          ))}
+        </View>
+        <View className="min-h-2 flex-1" />
+        <View>
+          <View className="flex-row flex-wrap justify-center gap-2 bg-[red]">
+            <PinyinOptionButton pinyin="nī" shortcutKey="1" />
+            <PinyinOptionButton pinyin="ní" shortcutKey="2" />
+            <PinyinOptionButton pinyin="nǐ" shortcutKey="3" />
+            <PinyinOptionButton pinyin="nì" shortcutKey="4" />
+            <PinyinOptionButton pinyin="ni" shortcutKey="5" />
+          </View>
+          <TextInputSingle placeholder="Search pinyin" />
+        </View>
+      </View>
     </Skeleton>
   );
 }

--- a/projects/app/src/client/ui/ReferencePage.tsx
+++ b/projects/app/src/client/ui/ReferencePage.tsx
@@ -10,7 +10,7 @@ export const ReferencePage = ({
 }) => {
   return (
     <View className="flex-1 bg-background">
-      <View className="w-full max-w-[600px] flex-col self-center overflow-hidden lg:my-4 lg:rounded-t-lg">
+      <View className="w-full max-w-[600px] self-center overflow-hidden lg:my-4 lg:rounded-t-lg">
         {header}
 
         <View className="gap-[12px] p-[12px] pt-quiz-px">{body}</View>

--- a/projects/app/src/client/ui/WikiHanziInterpretationPanel.tsx
+++ b/projects/app/src/client/ui/WikiHanziInterpretationPanel.tsx
@@ -22,7 +22,7 @@ export const WikiHanziInterpretationPanel = ({
       <View className="gap-4 rounded-xl bg-primary-5 p-4">
         {wikiEntry.data.components.map((component, i) => {
           return (
-            <View key={i} className="flex-col gap-1">
+            <View key={i} className="gap-1">
               <Text className="hhh-text-body">
                 {component.title ??
                   (component.hanziWord == null ? null : (

--- a/projects/app/src/client/ui/WikiHanziWordModal.tsx
+++ b/projects/app/src/client/ui/WikiHanziWordModal.tsx
@@ -142,7 +142,7 @@ export const WikiHanziWordModal = ({
                   <View className="gap-4 rounded-xl bg-primary-5 p-4">
                     {wikiEntry.data.components.map((component, i) => {
                       return (
-                        <View key={i} className="flex-col gap-1">
+                        <View key={i} className="gap-1">
                           <Text className="hhh-text-body">
                             {component.title ??
                               (component.hanziWord == null ? null : (
@@ -205,7 +205,7 @@ export const WikiHanziWordModal = ({
                   <Text className="text-xs uppercase text-body/90">
                     Skills <DevLozenge />
                   </Text>
-                  <View className="flex-col gap-2 text-body">
+                  <View className="gap-2 text-body">
                     {skillStatesQuery.data.map(([skill, skillState], i) => (
                       <View key={i} className="flex-row items-center gap-2">
                         <Text>

--- a/projects/eslint-rules/index.cjs
+++ b/projects/eslint-rules/index.cjs
@@ -1,7 +1,9 @@
+const noRestrictedClasses = require("./no-restricted-css-classes.cjs");
 const reanimatedDefaultName = require("./reanimated-default-name.cjs");
 
 module.exports = {
   rules: {
+    "no-restricted-css-classes": noRestrictedClasses,
     "reanimated-default-name": reanimatedDefaultName,
   },
 };

--- a/projects/eslint-rules/moon.yml
+++ b/projects/eslint-rules/moon.yml
@@ -6,3 +6,12 @@ tasks:
       - "**/*"
     env:
       NODE_OPTIONS: --experimental-vm-modules $NODE_OPTIONS
+
+  testWatch:
+    command: node --test --watch --test-reporter=spec --import tsx "'**/*.test.{js,cjs}'"
+    preset: watcher
+    inputs:
+      - "!dist/"
+      - "**/*"
+    env:
+      NODE_OPTIONS: --experimental-vm-modules $NODE_OPTIONS

--- a/projects/eslint-rules/no-restricted-css-classes.cjs
+++ b/projects/eslint-rules/no-restricted-css-classes.cjs
@@ -1,0 +1,154 @@
+/**
+ * @typedef {import('eslint').Rule.RuleContext} RuleContext
+ * @typedef {import('eslint').Rule.Node} Node
+ * @typedef {import('estree').Literal} Literal
+ * @typedef {import('estree').TemplateLiteral} TemplateLiteral
+ * @typedef {import('eslint').Rule.RuleModule} RuleModule
+ */
+
+/** @type {RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Restricts specific CSS classes in string literals.",
+    },
+    messages: {
+      disallowedClass: 'CSS class "{{ className }}" is disallowed.',
+    },
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          classes: {
+            type: "array",
+            items: {
+              anyOf: [
+                { type: "string" },
+                {
+                  type: "object",
+                  properties: {
+                    name: { type: "string" },
+                    message: { type: "string" },
+                  },
+                  required: ["name"],
+                  additionalProperties: false,
+                },
+              ],
+            },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  /**
+   * @param {RuleContext} context
+   */
+  create(context) {
+    const options = context.options[0] || {};
+    // Support both string and object for classes
+    /** @type {Array<{name: string, message?: string}>} */
+    const classList = (options.classes || []).map(
+      /** @param {any} item */
+      (item) => (typeof item === "string" ? { name: item } : item),
+    );
+    const disallowedClasses = new Map(
+      classList.map((c) => [c.name, c.message]),
+    );
+
+    /**
+     * Remove disallowed classes from a class string
+     * @param {string} value
+     * @returns {string}
+     */
+    function removeDisallowedClasses(value) {
+      return value
+        .split(/\s+/)
+        .filter((cls) => !disallowedClasses.has(cls))
+        .join(" ");
+    }
+
+    /**
+     * @param {string} value
+     * @param {Literal | TemplateLiteral} node
+     * @returns
+     */
+    function checkString(value, node) {
+      const classNames = value.split(/\s+/);
+      for (const className of classNames) {
+        if (disallowedClasses.has(className)) {
+          const customMessage = disallowedClasses.get(className);
+          context.report({
+            node,
+            message:
+              customMessage || `CSS class \"${className}\" is disallowed.`,
+            fix: (fixer) => {
+              // Only fix if the node is a string literal or a simple template literal
+              if (node.type === "Literal" && typeof node.value === "string") {
+                const fixed = removeDisallowedClasses(node.value);
+                return fixer.replaceText(node, `"${escapeLiteral(fixed)}"`);
+              }
+              if (
+                node.type === "TemplateLiteral" &&
+                node.expressions.length === 0
+              ) {
+                const cooked = node.quasis.map((q) => q.value.cooked).join(" ");
+                const fixed = removeDisallowedClasses(cooked);
+                return fixer.replaceText(
+                  node,
+                  `\`${escapeTemplateLiteral(fixed)}\``,
+                );
+              }
+              return null;
+            },
+          });
+        }
+      }
+    }
+
+    return {
+      /**
+       * @param {Literal} node
+       */
+      Literal(node) {
+        if (typeof node.value !== "string") return;
+        checkString(node.value, node);
+      },
+      /**
+       * @param {TemplateLiteral} node
+       */
+      TemplateLiteral(node) {
+        if (node.expressions.length === 0) {
+          checkString(node.quasis.map((q) => q.value.cooked).join(" "), node);
+        }
+      },
+    };
+  },
+};
+
+/**
+ * Escape backticks, ${, and backslashes for template literals
+ *
+ * @param {string} str
+ */
+function escapeLiteral(str) {
+  return JSON.stringify(str).slice(1, -1);
+}
+
+/**
+ * Escape backticks, ${, and backslashes for template literals
+ *
+ * @param {string} str
+ */
+function escapeTemplateLiteral(str) {
+  return str
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\$\{/g, "\\${");
+}
+
+module.exports = rule;

--- a/projects/eslint-rules/no-restricted-css-classes.test.cjs
+++ b/projects/eslint-rules/no-restricted-css-classes.test.cjs
@@ -1,0 +1,128 @@
+const { RuleTester } = require("eslint");
+const rule = require("./no-restricted-css-classes.cjs");
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+  rules: {
+    "rule-to-test/no-restricted-css-classes": [
+      "error",
+      {
+        classes: [
+          // use the default message
+          "flex-col",
+          // use a custom message
+          { name: "flex-row", message: "Columns are better than rows." },
+        ],
+      },
+    ],
+  },
+});
+
+ruleTester.run("no-restricted-css-classes", rule, {
+  valid: [
+    {
+      // Shouldn't match "flex-col".
+      code: `const el = <div className="flex-column" />`,
+    },
+    {
+      // Shouldn't match "flex-col".
+      code: `const txt = "flex-column";`,
+    },
+  ],
+
+  invalid: [
+    // Tests for default message.
+    {
+      code: `const el = <div className="flex-col" />`,
+      errors: [
+        {
+          message: 'CSS class "flex-col" is disallowed.',
+        },
+      ],
+      output: `const el = <div className="" />`,
+    },
+    {
+      code: `const el = <div className="flex-col flex-wrap flex-1" />`,
+      errors: [
+        {
+          message: 'CSS class "flex-col" is disallowed.',
+        },
+      ],
+      output: `const el = <div className="flex-wrap flex-1" />`,
+    },
+    {
+      code: `const el = "flex-col flex-wrap flex-1";`,
+      errors: [
+        {
+          message: 'CSS class "flex-col" is disallowed.',
+        },
+      ],
+      output: `const el = "flex-wrap flex-1";`,
+    },
+    //
+    // Test for custom message.
+    //
+    {
+      code: `const el = <div className="flex-row" />`,
+      errors: [
+        {
+          message: "Columns are better than rows.",
+        },
+      ],
+      output: `const el = <div className="" />`,
+    },
+    {
+      code: `const el = <div className="flex-row flex-wrap flex-1" />`,
+      errors: [
+        {
+          message: "Columns are better than rows.",
+        },
+      ],
+      output: `const el = <div className="flex-wrap flex-1" />`,
+    },
+    {
+      code: `const el = "flex-row flex-wrap flex-1";`,
+      errors: [
+        {
+          message: "Columns are better than rows.",
+        },
+      ],
+      output: `const el = "flex-wrap flex-1";`,
+    },
+    {
+      code: "const el = `flex-row flex-wrap flex-1`;",
+      errors: [
+        {
+          message: "Columns are better than rows.",
+        },
+      ],
+      output: "const el = `flex-wrap flex-1`;",
+    },
+    {
+      code: `const el = "flex-row \\"";`,
+      errors: [
+        {
+          message: "Columns are better than rows.",
+        },
+      ],
+      output: `const el = "\\"";`,
+    },
+    {
+      code: "const el = `flex-row \\``;",
+      errors: [
+        {
+          message: "Columns are better than rows.",
+        },
+      ],
+      output: "const el = `\\``;",
+    },
+  ],
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a custom ESLint rule to restrict specific CSS class usage, such as disallowing "flex-col", with automatic code fixes and custom error messages.
  - Added a new task to run ESLint rule tests in watch mode.

- **Bug Fixes**
  - Updated various UI components to remove the restricted "flex-col" class, potentially altering layout behavior across multiple pages and components.

- **Refactor**
  - Renamed the `text` prop to `pinyin` in the PinyinOptionButton component for improved clarity.

- **Tests**
  - Added comprehensive tests for the new ESLint rule restricting CSS classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->