### PR TITLE
fix mistake grading for hanzi->pinyin quiz

### DIFF
--- a/projects/app/src/data/questions/hanziWordToPinyin.ts
+++ b/projects/app/src/data/questions/hanziWordToPinyin.ts
@@ -58,9 +58,9 @@ export function hanziToPinyinQuestionMistakes(
 
   for (const [i, expectedSyllables] of question.answers.entries()) {
     const isLastChance = i === question.answers.length - 1;
-    const isCorrect = expectedSyllables.every(
-      (syllable, i) => syllable === actualSyllables[i],
-    );
+    const isCorrect =
+      expectedSyllables.length === actualSyllables.length &&
+      expectedSyllables.every((syllable, i) => syllable === actualSyllables[i]);
 
     if (isCorrect) {
       return [];

--- a/projects/app/test/data/questions/hanziWordToPinyin.test.ts
+++ b/projects/app/test/data/questions/hanziWordToPinyin.test.ts
@@ -83,6 +83,8 @@ await test(`${hanziToPinyinQuestionMistakes.name} suite`, async () => {
     };
 
     const fixtures: [string, string[]][] = [
+      [`nǐ`, [`nǐ`]], // less syllables than the answer
+      [`nǐhǎomá`, [`nǐ`, `hǎo`, `má`]], // more syllables than the answer
       [`nihǎo`, [`ni`, `hǎo`]],
       [`ni  hǎo`, [`ni`, `hǎo`]],
       [`nǐhao`, [`nǐ`, `hao`]],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved answer validation for pinyin questions to ensure the number of syllables matches the expected answer, reducing false positives.

- **Tests**
  - Added new test cases to verify correct handling when the user's answer has more or fewer syllables than expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->