### PR TITLE
add replicache v8 tests for skill renames

### DIFF
--- a/projects/app/src/server/lib/replicache.ts
+++ b/projects/app/src/server/lib/replicache.ts
@@ -34,10 +34,14 @@ export async function push(
   userId: string,
   pushRequest: PushRequest,
 ): Promise<PushResponse> {
-  return await startSpan({ name: push.name }, async () => {
-    const impl = getImpl(pushRequest.schemaVersion);
-    return await impl.push(db, userId, pushRequest);
-  });
+  const { schemaVersion } = pushRequest;
+  return await startSpan(
+    { name: `${push.name} (${schemaVersion})` },
+    async () => {
+      const impl = getImpl(schemaVersion);
+      return await impl.push(db, userId, pushRequest);
+    },
+  );
 }
 
 export async function pull(
@@ -47,10 +51,14 @@ export async function pull(
 ): Promise<
   PullOkResponse | VersionNotSupportedResponse | ClientStateNotFoundResponse
 > {
-  return await startSpan({ name: pull.name }, async () => {
-    const impl = getImpl(pullRequest.schemaVersion);
-    return await impl.pull(db, userId, pullRequest);
-  });
+  const { schemaVersion } = pullRequest;
+  return await startSpan(
+    { name: `${pull.name} (${schemaVersion})` },
+    async () => {
+      const impl = getImpl(schemaVersion);
+      return await impl.pull(db, userId, pullRequest);
+    },
+  );
 }
 
 function getImpl(schemaVersion: string): Impl {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added tests to verify correct handling of skill renames during synchronization, ensuring patches reflect key changes for both skill state and skill rating records.

- **Style**
  - Improved span naming in synchronization logic to include schema version information for better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->