### PR TITLE
improve hanzi word rank calculation

### DIFF
--- a/projects/app/src/dictionary/dictionary.ts
+++ b/projects/app/src/dictionary/dictionary.ts
@@ -514,13 +514,15 @@ export function hanziTextFromHanziChar(hanziChar: HanziChar): HanziText {
   return hanziChar as unknown as HanziText;
 }
 
-export function isHanziWord(
+export const isHanziWord = memoize1(function isHanziWord(
   hanziOrHanziWord: HanziText | HanziWord,
 ): hanziOrHanziWord is HanziWord {
   return hanziOrHanziWord.includes(`:`);
-}
+});
 
-export function hanziFromHanziWord(hanziWord: HanziWord): HanziText {
+export const hanziFromHanziWord = memoize1(function hanziFromHanziWord(
+  hanziWord: HanziWord,
+): HanziText {
   const result = /^(.+?):/.exec(hanziWord);
   invariant(result != null, `couldn't parse HanziWord ${hanziWord}`);
 
@@ -528,17 +530,21 @@ export function hanziFromHanziWord(hanziWord: HanziWord): HanziText {
   invariant(hanzi != null, `couldn't parse hanzi (before :)`);
 
   return hanzi as HanziText;
-}
+});
 
-export function hanziCharsFromHanziWord(hanziWord: HanziWord): HanziChar[] {
-  const hanzi = hanziFromHanziWord(hanziWord);
-  return splitHanziText(hanzi);
-}
+export const hanziCharsFromHanziWord = memoize1(
+  function hanziCharsFromHanziWord(hanziWord: HanziWord): HanziChar[] {
+    const hanzi = hanziFromHanziWord(hanziWord);
+    return splitHanziText(hanzi);
+  },
+);
 
-export function meaningKeyFromHanziWord(hanziWord: HanziWord): string {
-  const hanzi = hanziFromHanziWord(hanziWord);
-  return hanziWord.slice(hanzi.length + 1 /* skip the : */);
-}
+export const meaningKeyFromHanziWord = memoize1(
+  function meaningKeyFromHanziWord(hanziWord: HanziWord): string {
+    const hanzi = hanziFromHanziWord(hanziWord);
+    return hanziWord.slice(hanzi.length + 1 /* skip the : */);
+  },
+);
 
 export function buildHanziWord(hanzi: string, meaningKey: string): HanziWord {
   return `${hanzi}:${meaningKey}`;

--- a/projects/app/src/util/collections.ts
+++ b/projects/app/src/util/collections.ts
@@ -263,9 +263,17 @@ export function memoize0<R>(
   return Object.assign(memoFn, { isCached: () => cacheSet });
 }
 
-export function memoize1<T extends string, R>(
-  fn: (input: T) => R,
-): ((input: T) => R) & { isCached: (input: T) => boolean } {
+/**
+ * Memoize a function that takes a single argument.
+ *
+ * The cache is a Map that is never cleared, so only use this for functions with
+ * bounded input.
+ */
+export function memoize1<
+  R,
+  Fn extends (input: never) => R,
+  T extends Parameters<Fn>[0],
+>(fn: Fn): Fn & { isCached: (input: T) => boolean } {
   const cache = new Map<T, R>();
   const memoFn = function <This>(this: This, input: T) {
     if (cache.has(input)) {
@@ -275,7 +283,7 @@ export function memoize1<T extends string, R>(
     const ret = fn.call(this, input);
     cache.set(input, ret);
     return ret;
-  };
+  } as Fn;
   Object.defineProperty(memoFn, `name`, { value: fn.name });
   return Object.assign(memoFn, {
     isCached: (input: T) => cache.has(input),

--- a/projects/app/src/util/fsrs.ts
+++ b/projects/app/src/util/fsrs.ts
@@ -270,12 +270,14 @@ function intervalModifier(requestRetentionPercentile: number): number {
   );
 }
 
+export const fsrsStabilityThreshold = 30;
+
 /**
  * Return true if the skill is learned enough to build upon. (i.e. if other
  * skills depend on this, they can be introduced at this point).
  */
 export function fsrsIsStable(options: Pick<FsrsState, `stability`>): boolean {
-  return options.stability >= 30;
+  return options.stability >= fsrsStabilityThreshold;
 }
 
 export function ratingName(rating: Rating) {

--- a/projects/app/test/data/skills.test.ts
+++ b/projects/app/test/data/skills.test.ts
@@ -875,14 +875,14 @@ await test(`${getHanziWordRank.name} suite`, async () => {
     );
   }
 
-  await test(`it defaults to rank 1`, async () => {
+  await test(`it defaults to no rank`, async () => {
     expect(
       getHanziWordRank({
         hanziWord: `一:one`,
-        skillSrsStates: new Map(),
+        skillSrsStates: makeSkillSrsStates({}),
         rankRules,
       }),
-    ).toEqual({ currentRank: 1, completion: 0 });
+    ).toEqual({ hanziWord: `一:one`, rank: 0, completion: 0 });
   });
 
   await test(`single skill per rank`, async () => {
@@ -901,7 +901,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
       },
     ];
 
-    await test(`no goals met, current rank is 1`, async () => {
+    await test(`no goals started, rank is 0`, async () => {
       const skillSrsStates = makeSkillSrsStates({});
 
       const result = getHanziWordRank({
@@ -910,7 +910,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 1, completion: 0 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 0, completion: 0 });
     });
 
     await test(`rank 1 goals met, current rank is 2`, async () => {
@@ -924,7 +924,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 2, completion: 0 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 2, completion: 0 });
     });
 
     await test(`rank 1 and 2 goals met, current rank is 3`, async () => {
@@ -939,7 +939,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 3, completion: 0 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 3, completion: 0 });
     });
 
     await test(`rank 1 goals missed, but rank 2 goals met, current rank is 3`, async () => {
@@ -954,7 +954,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 3, completion: 0 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 3, completion: 0 });
     });
 
     await test(`rank 1 goals not met, progress is fraction of stability`, async () => {
@@ -968,7 +968,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 1, completion: 0.5 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 1, completion: 0.5 });
     });
 
     await test(`rank 2 goals not met, progress is fraction of stability`, async () => {
@@ -983,7 +983,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 2, completion: 0.2 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 2, completion: 0.2 });
     });
 
     await test(`rank 3 goals not met, progress is fraction of stability`, async () => {
@@ -999,7 +999,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 3, completion: 0.8 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 3, completion: 0.8 });
     });
   });
 
@@ -1022,7 +1022,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
       },
     ];
 
-    await test(`no goals met, current rank is 1`, async () => {
+    await test(`no skills attempted, current rank is null`, async () => {
       const skillSrsStates = makeSkillSrsStates({});
 
       const result = getHanziWordRank({
@@ -1031,7 +1031,25 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 1, completion: 0 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 0, completion: 0 });
+    });
+
+    await test(`rank 1 when the skill has been started`, async () => {
+      const skillSrsStates = makeSkillSrsStates({
+        "he:一:one": 1,
+      });
+
+      const result = getHanziWordRank({
+        hanziWord: `一:one`,
+        skillSrsStates,
+        rankRules,
+      });
+
+      expect(result).toEqual({
+        hanziWord: `一:one`,
+        rank: 1,
+        completion: 1 / 50,
+      });
     });
 
     await test(`rank 1 goals met, current rank is 2`, async () => {
@@ -1045,7 +1063,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 2, completion: 0 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 2, completion: 0 });
     });
 
     await test(`rank 1 and 2 goals met, current rank is 3`, async () => {
@@ -1061,7 +1079,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 3, completion: 0 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 3, completion: 0 });
     });
 
     await test(`rank 1 goals missed, but rank 2 goals met, current rank is 3`, async () => {
@@ -1077,7 +1095,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 3, completion: 0 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 3, completion: 0 });
     });
 
     await test(`rank 2 goals not met, progress is fraction of stability`, async () => {
@@ -1092,7 +1110,22 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 2, completion: 0.1 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 2, completion: 0.1 });
+    });
+
+    await test(`rank 2 goals not fully met, but one skill is more advanced than required`, async () => {
+      const skillSrsStates = makeSkillSrsStates({
+        "he:一:one": 50,
+        "hpi:一:one": 100,
+      });
+
+      const result = getHanziWordRank({
+        hanziWord: `一:one`,
+        skillSrsStates,
+        rankRules,
+      });
+
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 2, completion: 0.5 });
     });
 
     await test(`rank 3 goals not met, progress is fraction of stability`, async () => {
@@ -1109,7 +1142,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 3, completion: 0.4 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 3, completion: 0.4 });
     });
   });
 
@@ -1136,7 +1169,7 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 2, completion: 0.5 });
+      expect(result).toEqual({ hanziWord: `一:one`, rank: 2, completion: 0.5 });
     });
   });
 
@@ -1168,7 +1201,11 @@ await test(`${getHanziWordRank.name} suite`, async () => {
         rankRules,
       });
 
-      expect(result).toEqual({ currentRank: 3, completion: 0.5 });
+      expect(result).toEqual({
+        hanziWord: `一:one`,
+        rank: 3,
+        completion: 0.5,
+      });
     });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Skills are now grouped and displayed by rank, including a new rank 0 category for unstarted skills.
  - Styling updates visually distinguish rank 0 skills from other ranks.
  - Improved skill progress bars: only shown when there is progress.

- **Improvements**
  - Enhanced performance for dictionary-related functions through memoization.
  - More precise and clear calculation and display of skill ranks and completion progress.

- **Bug Fixes**
  - Layout consistency improved by adding invisible filler tiles to skill groups.

- **Tests**
  - Expanded and updated tests for skill ranking logic and memoization utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->