### PR TITLE
queue button lozenge improvements

### DIFF
--- a/projects/app/src/client/ui/QuizQueueButton.tsx
+++ b/projects/app/src/client/ui/QuizQueueButton.tsx
@@ -55,7 +55,7 @@ function CountLozenge({
   mode: `overdue` | `due` | `new`;
   className?: string;
 }) {
-  const countText = count >= 100 ? `99+` : `${count}`;
+  const countText = count >= 999 ? `999+` : `${count}`;
   return (
     <View className={countLozengePillClass({ mode, className })}>
       <Text className="text-[10px] font-bold tabular-nums text-bg">

--- a/projects/app/src/client/ui/QuizQueueButton.tsx
+++ b/projects/app/src/client/ui/QuizQueueButton.tsx
@@ -41,22 +41,8 @@ export function QuizQueueButton({
                 : `new`
           }
         />
-      ) : (
-        <CheckBadge />
-      )}
+      ) : null}
     </Link>
-  );
-}
-
-function CheckBadge() {
-  return (
-    <View className="absolute left-[55%] top-[62%] size-quiz-px rounded-full bg-bg p-[2px]">
-      <IconImage
-        size={12}
-        className="self-center rounded-full bg-fg/30 text-fg"
-        source={require(`@/assets/icons/check.svg`)}
-      />
-    </View>
   );
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated badge display in the quiz queue to show "999+" for counts of 999 or more, instead of "99+" for counts of 100 or more.

- **Refactor**
  - Improved the quiz queue button by removing the checkmark badge when the queue count is zero or not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->